### PR TITLE
fix(main.tex): remove the extension in \include

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -65,6 +65,6 @@
 	\tableofcontents
 \end{frame}
 
-\include{contents/basis.tex}
+\include{contents/basis}
 
 \end{document}


### PR DESCRIPTION
The extension should be avoided in `\include`. It doesn't work both locally and using Overleaf.