### PR TITLE
feat: logo position

### DIFF
--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/04 sjtubeamer color theme v2.0.0]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/17 sjtubeamer color theme v2.1.0]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/17 sjtubeamer color theme v2.1.0]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/22 sjtubeamer color theme v2.1.0]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/22 sjtubeamer color theme v2.1.0]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/25 sjtubeamer color theme v2.2.0]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/04 sjtubeamer font theme v2.0.0]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/17 sjtubeamer font theme v2.1.0]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/17 sjtubeamer font theme v2.1.0]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/22 sjtubeamer font theme v2.1.0]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/22 sjtubeamer font theme v2.1.0]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/25 sjtubeamer font theme v2.2.0]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -108,16 +108,22 @@
 \fi
 \newdimen\beamer@sidebarwidth
 \beamer@sidebarwidth=0pt
+\def\coverpage#1{
+  {
+    \tikzset{external/export=false}
+    \let\oldlogocolor=\sjtubeamer@logocolor%
+    \ifdim\beamer@sidebarwidth=0pt %
+      \usebeamertemplate*{#1}
+    \else
+      \hspace*{-0.5\beamer@sidebarwidth}\parbox[t]{\textwidth}{
+        \usebeamertemplate*{#1}
+      }
+    \fi
+    \let\sjtubeamer@logocolor=\oldlogocolor%
+  }
+}
 \def\titlepage{
-  \let\oldlogocolor=\sjtubeamer@logocolor%
-  \ifdim\beamer@sidebarwidth=0pt %
-    \usebeamertemplate*{title page}
-  \else
-    \hspace*{-0.5\beamer@sidebarwidth}\parbox[t]{\textwidth}{
-      \usebeamertemplate*{title page}
-    }
-  \fi
-  \let\sjtubeamer@logocolor=\oldlogocolor%
+  \coverpage{title page}
 }
 \renewcommand{\maketitle}[1][\sjtubeamer@inner@cover]{
   \setbeamertemplate{title page}[#1]
@@ -128,15 +134,7 @@
   \setbeamertemplate{title page}[\sjtubeamer@inner@cover]
 }
 \def\bottompage{
-  \let\oldlogocolor=\sjtubeamer@logocolor%
-  \ifdim\beamer@sidebarwidth=0pt %
-    \usebeamertemplate*{bottom page}
-  \else
-    \hspace*{-0.5\beamer@sidebarwidth}\parbox[t]{\textwidth}{
-      \usebeamertemplate*{bottom page}
-    }
-  \fi
-  \let\sjtubeamer@logocolor=\oldlogocolor%
+  \coverpage{bottom page}
 }
 \if\EqualOption{inner}{lang}{cn}%
   \def\bottomthanks{谢\,谢}
@@ -368,7 +366,7 @@
     \fi%
   }
 }
-\defbeamertemplate*{footnote}{sjtubeamermin}
+\defbeamertemplate*{footnote}{sjtubeamer}
 {
   \usebeamerfont{footnote}
   \usebeamercolor[fg]{footnote}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/17 sjtubeamer inner theme v2.1.0]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/22 sjtubeamer inner theme v2.1.0]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@inner@cover{maxplus}}
@@ -70,18 +70,10 @@
   \fi
 \fi
 \newcommand{\bgcenterbox}[1]{
-  \let\oldlogocolor=\sjtubeamer@logocolor%
-  \def\sjtubeamer@logocolor{cprimary!50}
-  \vbox to \paperheight{
-    \vfil
-    \hbox to \paperwidth{
-      \hfil
-      #1
-      \hfil
-    }
-    \vfil
+  \parbox[c][1.1\paperheight][c]{\paperwidth}{
+    \def\sjtubeamer@logocolor{cprimary!50}
+    \centering\resizebox{\paperwidth}{!}{#1}
   }
-  \let\sjtubeamer@logocolor=\oldlogocolor%
 }
 \if\EqualOption{inner}{cover}{maxplus}
   \titlegraphic{\includegraphics{vi/sjtuphoto.jpg}}
@@ -90,9 +82,7 @@
     \usebeamercolor{palatte primary}
     \titlegraphic{\sjtubg[opacity=0.2]}
     \setbeamertemplate{background}
-    {
-      \parbox[c][1.1\paperheight][c]{\paperwidth}{\centering\resizebox{\paperwidth}{!}{\sjtubg[cprimary!50,opacity=0.2]}}
-    }
+    {\bgcenterbox{\sjtubg[cprimary!50,opacity=0.2]}}
   \else
     \if\EqualOption{inner}{cover}{min}
       \titlegraphic{\includegraphics{vi/sjtuphoto.jpg}}
@@ -112,7 +102,6 @@
 \def\coverpage#1{
   {
     \tikzset{external/export=false}
-    \let\oldlogocolor=\sjtubeamer@logocolor%
     \ifdim\beamer@sidebarwidth=0pt %
       \usebeamertemplate*{#1}
     \else
@@ -120,19 +109,19 @@
         \usebeamertemplate*{#1}
       }
     \fi
-    \let\sjtubeamer@logocolor=\oldlogocolor%
   }
 }
 \def\titlepage{
   \coverpage{title page}
 }
 \renewcommand{\maketitle}[1][\sjtubeamer@inner@cover]{
-  \setbeamertemplate{title page}[#1]
-  \ifbeamer@inframe\titlepage\else
-    \begin{frame}[plain]
-      \titlepage
-    \end{frame}\fi
-  \setbeamertemplate{title page}[\sjtubeamer@inner@cover]
+  {
+    \setbeamertemplate{title page}[#1]
+    \ifbeamer@inframe\titlepage\else
+      \begin{frame}[plain]
+        \titlepage
+      \end{frame}\fi
+  }
 }
 \def\bottompage{
   \coverpage{bottom page}
@@ -143,12 +132,13 @@
   \def\bottomthanks{Thank You}
 \fi%
 \newcommand{\makebottom}[1][\sjtubeamer@inner@cover]{
-  \setbeamertemplate{bottom page}[#1][\bottomthanks]
-  \ifbeamer@inframe\bottompage\else
-    \begin{frame}[plain]
-      \bottompage
-    \end{frame}\fi
-  \setbeamertemplate{bottom page}[\sjtubeamer@inner@cover][\bottomthanks]
+  {
+    \setbeamertemplate{bottom page}[#1][\bottomthanks]
+    \ifbeamer@inframe\bottompage\else
+      \begin{frame}[plain]
+        \bottompage
+      \end{frame}\fi
+  }
 }
 \RequirePackage{sjtucover}
 \defbeamertemplate*{part page}{sjtubeamer}[1][]
@@ -363,7 +353,8 @@
         \Hy@Warning{%
           Option `#1' has already been used,\MessageBreak
           setting the option has no effect%
-        }\fi%
+        }
+      \fi%
     \fi%
   }
 }

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/22 sjtubeamer inner theme v2.1.0]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/25 sjtubeamer inner theme v2.2.0]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@inner@cover{maxplus}}
@@ -357,14 +357,6 @@
       \fi%
     \fi%
   }
-}
-\defbeamertemplate*{footnote}{sjtubeamer}
-{
-  \usebeamerfont{footnote}
-  \usebeamercolor[fg]{footnote}
-  \parindent 0.5em\noindent%
-  \raggedright
-  \hbox to 1.5em{\hfil\insertfootnotemark}\insertfootnotetext\par%
 }
 \endinput
 %%

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/04 sjtubeamer inner theme v2.0.0]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/17 sjtubeamer inner theme v2.1.0]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@inner@cover{maxplus}}
@@ -58,6 +58,7 @@
 \RequirePackage{tcolorbox}
 \tcbuselibrary{skins}
 \tcbuselibrary{listingsutf8}
+\tcbset{shield externalize}
 \usebeamercolor{palette primary}
 \if\EqualOption{inner}{cover}{max}
   \logo{\resizebox{!}{1cm}{\sjtubadge}}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -150,7 +150,7 @@
   \setbeamertemplate{bottom page}[\sjtubeamer@inner@cover][\bottomthanks]
 }
 \RequirePackage{sjtucover}
-\defbeamertemplate*{part page}{sjtubeamermin}[1][]
+\defbeamertemplate*{part page}{sjtubeamer}[1][]
 {
   \vfill
   \vskip 8pt
@@ -195,7 +195,7 @@
     \usebeamerfont{section title}\insertsection\par
   \end{beamercolorbox}
 }
-\defbeamertemplate*{section page}{sjtubeamermin}[1][]
+\defbeamertemplate*{section page}{sjtubeamer}[1][]
 {
   \vfill
   \begingroup
@@ -203,7 +203,7 @@
   \endgroup
   \vfill
 }
-\defbeamertemplate*{subsection page}{sjtubeamermin}[1][]
+\defbeamertemplate*{subsection page}{sjtubeamer}[1][]
 {
   \vfill
   \begingroup

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -33,51 +33,11 @@
 \DefineOption{outer}{nav}{tree}
 \DefineOption{outer}{nav}{smoothtree}
 \ExecuteOptionsBeamer{miniframes}
-\DefineOption{outer}{logopos}{topleft}
 \DefineOption{outer}{logopos}{topright}
 \DefineOption{outer}{logopos}{bottomright}
-\DefineOption{outer}{logopos}{bottomleft}
 \ExecuteOptionsBeamer{bottomright}
 \ProcessOptionsBeamer
 \beamer@compresstrue
-\def\insertouterlogo{
-  \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}
-}
-\def\inserttitlesubtitle#1{
-  \ifx\insertframesubtitle\@empty\vskip-2pt%
-  \else\vskip-1ex\fi%
-  \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
-  \strut\insertframetitle\strut\par%
-  {%
-    \ifx\insertframesubtitle\@empty%
-    \else%
-    {
-      \usebeamerfont{framesubtitle}
-      \usebeamercolor[fg]{framesubtitle}
-      \strut\insertframesubtitle\strut\par
-    }%
-    \fi
-  }%
-  \vskip-1ex%
-}
-\if\EqualOption{outer}{logopos}{topleft}
-  \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
-  {%
-  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
-    \@tempdima=\textwidth%
-    \advance\@tempdima by\beamer@leftmargin%
-    \advance\@tempdima by\beamer@rightmargin%
-    \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
-      \hbox{
-        \insertouterlogo
-        \vbox{
-          \inserttitlesubtitle{#1}
-        }
-      }
-      \if@tempswa\else\vskip-.3cm\fi%
-    \end{beamercolorbox}%
-  }
-\fi
 \if\EqualOption{outer}{logopos}{topright}
   \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
   {%
@@ -86,12 +46,30 @@
     \advance\@tempdima by\beamer@leftmargin%
     \advance\@tempdima by\beamer@rightmargin%
     \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
-      \inserttitlesubtitle{#1}
+      \begingroup
+      \usebeamerfont{frametitle}
+      \vbox{}
+      \ifx\insertframesubtitle\@empty\vskip-2pt%
+      \else\vskip-1ex\fi%
+      \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
+      \strut\insertframetitle\strut\par%
+      {%
+        \ifx\insertframesubtitle\@empty%
+        \else%
+        {
+          \usebeamerfont{framesubtitle}
+          \usebeamercolor[fg]{framesubtitle}
+          \strut\insertframesubtitle\strut\par
+        }%
+        \fi
+      }%
+      \vskip-1ex%
+      \endgroup%
       \raggedleft%
       \begingroup
       \ifx\insertframesubtitle\@empty\vskip-2.5ex%
       \else\vskip-3.5ex\fi%
-      \insertouterlogo\hspace*{5pt}%
+      \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}\hspace*{5pt}%
       \endgroup%
       \ifx\insertframesubtitle\@empty%
       \else\vskip0.5ex\fi%
@@ -122,19 +100,11 @@
     }
   }
 }
-\if\EqualOption{outer}{logopos}{bottomleft}
-  \addtobeamertemplate{footline}{
-    \rlap{\raisebox{3ex}[0pt][0pt]{\insertouterlogo}}
-    \hfill%
-    \usebeamertemplate***{navigation symbols}%
-    \hspace*{0.1cm}\par
-    \vskip 4pt
-  }{}
-\else\if\EqualOption{outer}{logopos}{bottomright}
+\if\EqualOption{outer}{logopos}{bottomright}
   \addtobeamertemplate{footline}{
     \hfill%
     \usebeamertemplate***{navigation symbols}%
-    \llap{\raisebox{1pc}[0pt][0pt]{\insertouterlogo}}
+    \llap{\raisebox{1pc}[0pt][0pt]{\insertlogo}}
     \hspace*{0.1cm}\par
     \vskip 4pt
   }{}
@@ -145,7 +115,7 @@
     \hspace*{0.1cm}\par
     \vskip 4pt
   }{}
-\fi\fi
+\fi
 \setbeamertemplate{page number in head/foot}{}
 \endinput
 %%

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -39,49 +39,53 @@
 \ProcessOptionsBeamer
 \beamer@compresstrue
 \if\EqualOption{outer}{logopos}{topright}
-  \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
-  {%
-  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
-    \@tempdima=\textwidth%
-    \advance\@tempdima by\beamer@leftmargin%
-    \advance\@tempdima by\beamer@rightmargin%
-    \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
-      \begingroup
-      \usebeamerfont{frametitle}
-      \vbox{}
-      \ifx\insertframesubtitle\@empty\vskip-2pt%
-      \else\vskip-1ex\fi%
-      \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
-      \strut\insertframetitle\strut\par%
-      {%
-        \ifx\insertframesubtitle\@empty%
-        \else%
-        {
-          \usebeamerfont{framesubtitle}
-          \usebeamercolor[fg]{framesubtitle}
-          \strut\insertframesubtitle\strut\par
+  \AtBeginDocument{
+    \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+    {%
+    \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+      \@tempdima=\textwidth%
+      \advance\@tempdima by\beamer@leftmargin%
+      \advance\@tempdima by\beamer@rightmargin%
+      \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+        \begingroup
+        \usebeamerfont{frametitle}
+        \vbox{}
+        \ifx\insertframesubtitle\@empty\vskip-2pt%
+        \else\vskip-1ex\fi%
+        \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
+        \strut\insertframetitle\strut\par%
+        {%
+          \ifx\insertframesubtitle\@empty%
+          \else%
+          {
+            \usebeamerfont{framesubtitle}
+            \usebeamercolor[fg]{framesubtitle}
+            \strut\insertframesubtitle\strut\par
+          }%
+          \fi
         }%
-        \fi
-      }%
-      \vskip-1ex%
-      \endgroup%
-      \raggedleft%
-      \begingroup
-      \ifx\insertframesubtitle\@empty\vskip-2.5ex%
-      \else\vskip-3.5ex\fi%
-      \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}\hspace*{5pt}%
-      \endgroup%
-      \ifx\insertframesubtitle\@empty%
-      \else\vskip0.5ex\fi%
-      \if@tempswa\else\vskip-.3cm\fi%
-    \end{beamercolorbox}%
+        \vskip-1ex%
+        \endgroup%
+        \raggedleft%
+        \begingroup
+        \ifx\insertframesubtitle\@empty\vskip-2.5ex%
+        \else\vskip-3.5ex\fi%
+        \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}\hspace*{5pt}%
+        \endgroup%
+        \ifx\insertframesubtitle\@empty%
+        \else\vskip0.5ex\fi%
+        \if@tempswa\else\vskip-.3cm\fi%
+      \end{beamercolorbox}%
+    }
   }
 \fi
 \if\EqualOption{outer}{nav}{miniframes}
   \useoutertheme[footline=institutetitle]{miniframes}
 \else\if\EqualOption{outer}{nav}{sidebar}
     \useoutertheme{sidebar}
-    \setbeamertemplate{frametitle}[sidebar theme]
+    \AtBeginDocument{
+      \setbeamertemplate{frametitle}[sidebar theme]
+    }
   \else
     \useoutertheme{\sjtubeamer@outer@nav}
     \setbeamercolor{title in head/foot}{use=structure,bg=white,fg=structure.fg}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -35,16 +35,55 @@
 \ExecuteOptionsBeamer{miniframes}
 \ProcessOptionsBeamer
 \beamer@compresstrue
+\defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+{%
+  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+  \@tempdima=\textwidth%
+  \advance\@tempdima by\beamer@leftmargin%
+  \advance\@tempdima by\beamer@rightmargin%
+  \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+    \begingroup
+    \usebeamerfont{frametitle}
+    \vbox{}
+    \ifx\insertframesubtitle\@empty\vskip-2pt%
+    \else\vskip-1ex\fi%
+    \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
+    \strut\insertframetitle\strut\par%
+    {%
+      \ifx\insertframesubtitle\@empty%
+      \else%
+      {
+        \usebeamerfont{framesubtitle}
+        \usebeamercolor[fg]{framesubtitle}
+        \strut\insertframesubtitle\strut\par
+      }%
+      \fi
+    }%
+    \vskip-1ex%
+    \endgroup%
+    \raggedleft%
+    \begingroup
+    \ifx\insertframesubtitle\@empty\vskip-2.5ex%
+    \else\vskip-3.5ex\fi%
+    {\resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}}\hspace*{5pt}%
+    \endgroup%
+    \ifx\insertframesubtitle\@empty%
+    \else\vskip0.5ex\fi%
+    \if@tempswa\else\vskip-.3cm\fi%
+  \end{beamercolorbox}%
+}
 \if\EqualOption{outer}{nav}{miniframes}
   \useoutertheme[footline=institutetitle]{miniframes}
 \else\if\EqualOption{outer}{nav}{sidebar}
     \useoutertheme{sidebar}
+    \setbeamertemplate{frametitle}[sidebar theme]
   \else
     \useoutertheme{\sjtubeamer@outer@nav}
     \setbeamercolor{title in head/foot}{use=structure,bg=white,fg=structure.fg}
   \fi\fi
 \setbeamercolor{frametitle}{use=titlelike,bg=white,fg=titlelike.fg}
 \setbeamercolor{frametitle right}{parent=subsection in head/foot}
+\setbeamertemplate{sidebar right}{}
 \addtobeamertemplate{navigation symbols}{}{
   \hbox{
     \raisebox{1.2pt}[0pt][0pt]{
@@ -56,6 +95,12 @@
     }
   }
 }
+\addtobeamertemplate{footline}{
+  \hfill%
+  \usebeamertemplate***{navigation symbols}%
+  \hspace*{0.1cm}\par
+  \vskip 4pt
+}{}
 \setbeamertemplate{page number in head/foot}{}
 \endinput
 %%

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/22 sjtubeamer outer theme v2.1.0]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/25 sjtubeamer outer theme v2.2.0]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}
@@ -33,45 +33,72 @@
 \DefineOption{outer}{nav}{tree}
 \DefineOption{outer}{nav}{smoothtree}
 \ExecuteOptionsBeamer{miniframes}
+\DefineOption{outer}{logopos}{topleft}
+\DefineOption{outer}{logopos}{topright}
+\DefineOption{outer}{logopos}{bottomright}
+\DefineOption{outer}{logopos}{bottomleft}
+\ExecuteOptionsBeamer{bottomright}
 \ProcessOptionsBeamer
 \beamer@compresstrue
-\defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
-{%
-  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
-  \@tempdima=\textwidth%
-  \advance\@tempdima by\beamer@leftmargin%
-  \advance\@tempdima by\beamer@rightmargin%
-  \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
-    \begingroup
-    \usebeamerfont{frametitle}
-    \vbox{}
-    \ifx\insertframesubtitle\@empty\vskip-2pt%
-    \else\vskip-1ex\fi%
-    \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
-    \strut\insertframetitle\strut\par%
-    {%
-      \ifx\insertframesubtitle\@empty%
-      \else%
-      {
-        \usebeamerfont{framesubtitle}
-        \usebeamercolor[fg]{framesubtitle}
-        \strut\insertframesubtitle\strut\par
-      }%
-      \fi
-    }%
-    \vskip-1ex%
-    \endgroup%
-    \raggedleft%
-    \begingroup
-    \ifx\insertframesubtitle\@empty\vskip-2.5ex%
-    \else\vskip-3.5ex\fi%
-    {\resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}}\hspace*{5pt}%
-    \endgroup%
-    \ifx\insertframesubtitle\@empty%
-    \else\vskip0.5ex\fi%
-    \if@tempswa\else\vskip-.3cm\fi%
-  \end{beamercolorbox}%
+\def\insertouterlogo{
+  \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}
 }
+\def\inserttitlesubtitle#1{
+  \ifx\insertframesubtitle\@empty\vskip-2pt%
+  \else\vskip-1ex\fi%
+  \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
+  \strut\insertframetitle\strut\par%
+  {%
+    \ifx\insertframesubtitle\@empty%
+    \else%
+    {
+      \usebeamerfont{framesubtitle}
+      \usebeamercolor[fg]{framesubtitle}
+      \strut\insertframesubtitle\strut\par
+    }%
+    \fi
+  }%
+  \vskip-1ex%
+}
+\if\EqualOption{outer}{logopos}{topleft}
+  \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+  {%
+  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+    \@tempdima=\textwidth%
+    \advance\@tempdima by\beamer@leftmargin%
+    \advance\@tempdima by\beamer@rightmargin%
+    \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+      \hbox{
+        \insertouterlogo
+        \vbox{
+          \inserttitlesubtitle{#1}
+        }
+      }
+      \if@tempswa\else\vskip-.3cm\fi%
+    \end{beamercolorbox}%
+  }
+\fi
+\if\EqualOption{outer}{logopos}{topright}
+  \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+  {%
+  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+    \@tempdima=\textwidth%
+    \advance\@tempdima by\beamer@leftmargin%
+    \advance\@tempdima by\beamer@rightmargin%
+    \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+      \inserttitlesubtitle{#1}
+      \raggedleft%
+      \begingroup
+      \ifx\insertframesubtitle\@empty\vskip-2.5ex%
+      \else\vskip-3.5ex\fi%
+      \insertouterlogo\hspace*{5pt}%
+      \endgroup%
+      \ifx\insertframesubtitle\@empty%
+      \else\vskip0.5ex\fi%
+      \if@tempswa\else\vskip-.3cm\fi%
+    \end{beamercolorbox}%
+  }
+\fi
 \if\EqualOption{outer}{nav}{miniframes}
   \useoutertheme[footline=institutetitle]{miniframes}
 \else\if\EqualOption{outer}{nav}{sidebar}
@@ -95,12 +122,30 @@
     }
   }
 }
-\addtobeamertemplate{footline}{
-  \hfill%
-  \usebeamertemplate***{navigation symbols}%
-  \hspace*{0.1cm}\par
-  \vskip 4pt
-}{}
+\if\EqualOption{outer}{logopos}{bottomleft}
+  \addtobeamertemplate{footline}{
+    \rlap{\raisebox{3ex}[0pt][0pt]{\insertouterlogo}}
+    \hfill%
+    \usebeamertemplate***{navigation symbols}%
+    \hspace*{0.1cm}\par
+    \vskip 4pt
+  }{}
+\else\if\EqualOption{outer}{logopos}{bottomright}
+  \addtobeamertemplate{footline}{
+    \hfill%
+    \usebeamertemplate***{navigation symbols}%
+    \llap{\raisebox{1pc}[0pt][0pt]{\insertouterlogo}}
+    \hspace*{0.1cm}\par
+    \vskip 4pt
+  }{}
+\else
+  \addtobeamertemplate{footline}{
+    \hfill%
+    \usebeamertemplate***{navigation symbols}%
+    \hspace*{0.1cm}\par
+    \vskip 4pt
+  }{}
+\fi\fi
 \setbeamertemplate{page number in head/foot}{}
 \endinput
 %%

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/17 sjtubeamer outer theme v2.1.0]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/22 sjtubeamer outer theme v2.1.0]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/04 sjtubeamer outer theme v2.0.0]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/17 sjtubeamer outer theme v2.1.0]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,11 +21,16 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/09/22 sjtubeamer parent theme v2.1.0]
-\DeclareOptionBeamer{maxplus}{\def\sjtubeamer@cover{maxplus}}
-\DeclareOptionBeamer{max}{\def\sjtubeamer@cover{max}}
-\DeclareOptionBeamer{min}{\def\sjtubeamer@cover{min}}
-\DeclareOptionBeamer{my}{\def\sjtubeamer@cover{my}} % reserved for customization
+\ProvidesPackage{beamerthemesjtubeamer}[2021/09/25 sjtubeamer parent theme v2.2.0]
+\DeclareOptionBeamer{maxplus}{
+  \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topleft}}
+\DeclareOptionBeamer{max}{
+  \def\sjtubeamer@cover{max}\def\sjtubeamer@logopos{bottomright}}
+\DeclareOptionBeamer{min}{
+  \def\sjtubeamer@cover{min}\def\sjtubeamer@logopos{topright}}
+\DeclareOptionBeamer{my}{
+  \def\sjtubeamer@cover{my}\def\sjtubeamer@logopos{bottomleft}}
+    % reserved for customization
 \ExecuteOptionsBeamer{
   maxplus,
   min,
@@ -52,6 +57,10 @@
 \DeclareOptionBeamer{tree}{\def\sjtubeamer@nav{tree}}
 \DeclareOptionBeamer{smoothtree}{\def\sjtubeamer@nav{smoothtree}}
 \ExecuteOptionsBeamer{miniframes}
+\DeclareOptionBeamer{topleft}{\def\sjtubeamer@logopos{topleft}}
+\DeclareOptionBeamer{topright}{\def\sjtubeamer@logopos{topright}}
+\DeclareOptionBeamer{bottomright}{\def\sjtubeamer@logopos{bottomright}}
+\DeclareOptionBeamer{bottomleft}{\def\sjtubeamer@logopos{bottomleft}}
 \ProcessOptionsBeamer
 \PassOptionsToPackage{\sjtubeamer@cover}{beamerinnerthemesjtubeamer}
 \PassOptionsToPackage{\sjtubeamer@color}{beamercolorthemesjtubeamer}
@@ -59,6 +68,7 @@
 \PassOptionsToPackage{\sjtubeamer@lum}{beamercolorthemesjtubeamer}
 \PassOptionsToPackage{\sjtubeamer@lang}{beamerinnerthemesjtubeamer}
 \PassOptionsToPackage{\sjtubeamer@nav}{beamerouterthemesjtubeamer}
+\PassOptionsToPackage{\sjtubeamer@logopos}{beamerouterthemesjtubeamer}
 \mode<presentation>
 \usecolortheme{sjtubeamer}
 \usefonttheme{sjtubeamer}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/09/17 sjtubeamer parent theme v2.1.0]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/09/22 sjtubeamer parent theme v2.1.0]
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@cover{maxplus}}
 \DeclareOptionBeamer{max}{\def\sjtubeamer@cover{max}}
 \DeclareOptionBeamer{min}{\def\sjtubeamer@cover{min}}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -57,10 +57,8 @@
 \DeclareOptionBeamer{tree}{\def\sjtubeamer@nav{tree}}
 \DeclareOptionBeamer{smoothtree}{\def\sjtubeamer@nav{smoothtree}}
 \ExecuteOptionsBeamer{miniframes}
-\DeclareOptionBeamer{topleft}{\def\sjtubeamer@logopos{topleft}}
 \DeclareOptionBeamer{topright}{\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{bottomright}{\def\sjtubeamer@logopos{bottomright}}
-\DeclareOptionBeamer{bottomleft}{\def\sjtubeamer@logopos{bottomleft}}
 \ProcessOptionsBeamer
 \PassOptionsToPackage{\sjtubeamer@cover}{beamerinnerthemesjtubeamer}
 \PassOptionsToPackage{\sjtubeamer@color}{beamercolorthemesjtubeamer}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -23,13 +23,13 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{beamerthemesjtubeamer}[2021/09/25 sjtubeamer parent theme v2.2.0]
 \DeclareOptionBeamer{maxplus}{
-  \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topleft}}
+  \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{
   \def\sjtubeamer@cover{max}\def\sjtubeamer@logopos{bottomright}}
 \DeclareOptionBeamer{min}{
   \def\sjtubeamer@cover{min}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{my}{
-  \def\sjtubeamer@cover{my}\def\sjtubeamer@logopos{bottomleft}}
+  \def\sjtubeamer@cover{my}\def\sjtubeamer@logopos{bottomright}}
     % reserved for customization
 \ExecuteOptionsBeamer{
   maxplus,

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/09/04 sjtubeamer parent theme v2.0.0]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/09/17 sjtubeamer parent theme v2.1.0]
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@cover{maxplus}}
 \DeclareOptionBeamer{max}{\def\sjtubeamer@cover{max}}
 \DeclareOptionBeamer{min}{\def\sjtubeamer@cover{min}}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/09/04 cover library for sjtubeamer v2.0.0]
+\ProvidesPackage{sjtucover}[2021/09/17 cover library for sjtubeamer v2.1.0]
 \RequirePackage{sjtuvi}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@sjtucover@cover{maxplus}}
 \DeclareOptionBeamer{max}{\def\sjtubeamer@sjtucover@cover{max}}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/09/22 cover library for sjtubeamer v2.1.0]
+\ProvidesPackage{sjtucover}[2021/09/25 cover library for sjtubeamer v2.2.0]
 \RequirePackage{sjtuvi}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@sjtucover@cover{maxplus}}
 \DeclareOptionBeamer{max}{\def\sjtubeamer@sjtucover@cover{max}}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/09/17 cover library for sjtubeamer v2.1.0]
+\ProvidesPackage{sjtucover}[2021/09/22 cover library for sjtubeamer v2.1.0]
 \RequirePackage{sjtuvi}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@sjtucover@cover{maxplus}}
 \DeclareOptionBeamer{max}{\def\sjtubeamer@sjtucover@cover{max}}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -48,34 +48,34 @@
 \definecolor{sjtuBlueSecondary}{RGB}{51,141,39}      %lightgreen
 \definecolor{sjtuBlueTertiary}{RGB}{0,81,78}         %lightgray
 \newcommand{\definelogo}[3]{
-    % #1: file from vi/ folder
-    % #2: horizontal clip (0~1)
-    % #3: vertical clip (0~1)
-    \pgfmathparse{notgreater(#2,#3)}
-    \ifnum\pgfmathresult=1
-      \begin{tikzfadingfrompicture}[name=#1]
-        \fill[black] (-1,-1) rectangle (1,1);
-        \node {\includegraphics[width=1.5cm]{vi/#1}};
-      \end{tikzfadingfrompicture}
-    \else
-      \begin{tikzfadingfrompicture}[name=#1]
-        \fill[black] (-1,-1) rectangle (1,1);
-        \node {\includegraphics[height=1.5cm]{vi/#1}};
-      \end{tikzfadingfrompicture}
-    \fi
-    \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
-      % ##1: override color, or opacity=... (optional)
-      {
-        \tikzset{external/export=false}
-        \begin{tikzpicture}
-          \begin{scope}
-            \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
-            \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
-              (-1,-1) rectangle (1,1);
-          \end{scope}
-        \end{tikzpicture}
-      }
+  % #1: file from vi/ folder
+  % #2: horizontal clip (0~1)
+  % #3: vertical clip (0~1)
+  \pgfmathparse{notgreater(#2,#3)}
+  \ifnum\pgfmathresult=1
+    \begin{tikzfadingfrompicture}[name=#1]
+      \fill[black] (-1,-1) rectangle (1,1);
+      \node {\includegraphics[width=1.5cm]{vi/#1}};
+    \end{tikzfadingfrompicture}
+  \else
+    \begin{tikzfadingfrompicture}[name=#1]
+      \fill[black] (-1,-1) rectangle (1,1);
+      \node {\includegraphics[height=1.5cm]{vi/#1}};
+    \end{tikzfadingfrompicture}
+  \fi
+  \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
+    % ##1: override color, or opacity=... (optional)
+    {
+      \tikzset{external/export=false}
+      \begin{tikzpicture}
+        \begin{scope}
+          \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
+          \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
+            (-1,-1) rectangle (1,1);
+        \end{scope}
+      \end{tikzpicture}
     }
+  }
 }
 \def\sjtubeamer@logocolor{sjtuRedPrimary}
 \definelogo{sjtubadge}{0}{0}
@@ -162,7 +162,13 @@
     \pgfpathlineto{\pgfpointdecoratedpathlast}
   }
 }
-\tikzexternalize[prefix=cache/]
+\RequirePackage{pdftexcmds}
+\ifnum\pdf@shellescape=1
+  \AtEndPreamble{
+    \tikzexternalize[prefix=cache/]
+  }
+\else
+\fi
 \endinput
 %%
 %% End of file `sjtuvi.sty'.

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/09/22 Visual Identity System library for sjtubeamer v2.1.0]
+\ProvidesPackage{sjtuvi}[2021/09/25 Visual Identity System library for sjtubeamer v2.2.0]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/09/17 Visual Identity System library for sjtubeamer v2.1.0]
+\ProvidesPackage{sjtuvi}[2021/09/22 Visual Identity System library for sjtubeamer v2.1.0]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key
@@ -65,8 +65,7 @@
   \fi
   \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
     % ##1: override color, or opacity=... (optional)
-    \tikzexternaldisable
-    \begin{tikzpicture}
+    \begin{tikzpicture}[external/export=false]
       \begin{scope}
         \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
         \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
@@ -165,7 +164,6 @@
   \AtEndPreamble{
     \tikzexternalize[prefix=cache/]
   }
-\else
 \fi
 \endinput
 %%

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/09/04 Visual Identity System library for sjtubeamer v2.0.0]
+\ProvidesPackage{sjtuvi}[2021/09/17 Visual Identity System library for sjtubeamer v2.1.0]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key
@@ -65,16 +65,14 @@
   \fi
   \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
     % ##1: override color, or opacity=... (optional)
-    {
-      \tikzset{external/export=false}
-      \begin{tikzpicture}
-        \begin{scope}
-          \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
-          \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
-            (-1,-1) rectangle (1,1);
-        \end{scope}
-      \end{tikzpicture}
-    }
+    \tikzexternaldisable
+    \begin{tikzpicture}
+      \begin{scope}
+        \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
+        \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
+          (-1,-1) rectangle (1,1);
+      \end{scope}
+    \end{tikzpicture}
   }
 }
 \def\sjtubeamer@logocolor{sjtuRedPrimary}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -40,6 +40,7 @@
 \usetikzlibrary{patterns.meta}
 \usetikzlibrary{fadings}
 \usetikzlibrary{decorations.pathmorphing}
+\usetikzlibrary{external}
 \definecolor{sjtuRedPrimary}{RGB}{167,32,56}         %engred
 \definecolor{sjtuRedSecondary}{RGB}{240,131,0}       %orange
 \definecolor{sjtuRedTertiary}{RGB}{253,208,0}        %yellow
@@ -64,13 +65,16 @@
     \fi
     \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
       % ##1: override color, or opacity=... (optional)
-      \begin{tikzpicture}
-        \begin{scope}
-          \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
-          \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
-            (-1,-1) rectangle (1,1);
-        \end{scope}
-      \end{tikzpicture}
+      {
+        \tikzset{external/export=false}
+        \begin{tikzpicture}
+          \begin{scope}
+            \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
+            \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
+              (-1,-1) rectangle (1,1);
+          \end{scope}
+        \end{tikzpicture}
+      }
     }
 }
 \def\sjtubeamer@logocolor{sjtuRedPrimary}
@@ -158,6 +162,7 @@
     \pgfpathlineto{\pgfpointdecoratedpathlast}
   }
 }
+\tikzexternalize[prefix=cache/]
 \endinput
 %%
 %% End of file `sjtuvi.sty'.

--- a/src/build.lua
+++ b/src/build.lua
@@ -3,8 +3,8 @@
 module           = "sjtubeamer"
 
 sourcefiledir    = "source"
-sourcefiles      = {"*.ins","*.dtx","vi/"}
-installfiles     = {"*.sty","vi/"}
+sourcefiles      = {"*.ins","*.dtx","vi/","latexmkrc"}
+installfiles     = {"*.sty","vi/","latexmkrc"}
 
 docfiledir       = "doc"
 
@@ -59,7 +59,7 @@ end
 
 -- Generate tutorial files before compiling the doc.
 -- NOTICE: if you want to save the tourial step pdf,
---         please enter support/tutorial adn run cache_pdf.sh
+--         please enter support/tutorial and run cache_pdf.sh
 --         if you want to clean the cache, please run clean_pdf.sh 
 function typeset_demo_tasks()
     local errorlevel = 0

--- a/src/build.lua
+++ b/src/build.lua
@@ -3,8 +3,8 @@
 module           = "sjtubeamer"
 
 sourcefiledir    = "source"
-sourcefiles      = {"*.ins","*.dtx","vi/","latexmkrc"}
-installfiles     = {"*.sty","vi/","latexmkrc"}
+sourcefiles      = {"*.ins","*.dtx","vi/"}
+installfiles     = {"*.sty","vi/"}
 
 docfiledir       = "doc"
 

--- a/src/build.lua
+++ b/src/build.lua
@@ -16,7 +16,7 @@ end
 
 typesetfiles     = {"sjtubeamerdevguide.tex","sjtubeamer.tex"}
 -- typesetfiles     = {"sjtubeamer.tex"}
-typesetruns      = 1 -- for debug. Some reference may not be linked.
+-- typesetruns      = 1 -- for debug. Some reference may not be linked.
 -- typesetdemofiles = {"min.tex"}
 typesetsuppfiles = {"head.png","plant.jpg","test.csv","testgraph.tex","ref.bib","tutorial/"}
 
@@ -65,7 +65,10 @@ function typeset_demo_tasks()
     local errorlevel = 0
     local tutorialdir = typesetdir .. "/tutorial"
     local typesetcommand = typesetexe .. " " .. typesetopts   -- patch l3build
-    print("============================================================\n If you want to save the previous demo files\n Please move the pdf into the support/tutorial directory.\n============================================================")
+    print("============================================================")
+    print("If you want to save the previous demo files")
+    print("Please move the pdf into the support/tutorial directory.")
+    print("============================================================")
     for _, p in ipairs(filelist(tutorialdir, "step*.tex")) do
         local pdffilename = string.gsub(p,".tex",".pdf")
         if fileexists(tutorialdir .. "/" .. pdffilename) == false then

--- a/src/build.lua
+++ b/src/build.lua
@@ -3,8 +3,8 @@
 module           = "sjtubeamer"
 
 sourcefiledir    = "source"
-sourcefiles      = {"*.ins","*.dtx","vi/"}
-installfiles     = {"*.sty","vi/"}
+sourcefiles      = {"*.ins","*.dtx","vi/","latexmkrc"}
+installfiles     = {"*.sty","vi/","latexmkrc"}
 
 docfiledir       = "doc"
 
@@ -16,7 +16,7 @@ end
 
 typesetfiles     = {"sjtubeamerdevguide.tex","sjtubeamer.tex"}
 -- typesetfiles     = {"sjtubeamer.tex"}
--- typesetruns      = 1 -- for debug. Some reference may not be linked.
+typesetruns      = 1 -- for debug. Some reference may not be linked.
 -- typesetdemofiles = {"min.tex"}
 typesetsuppfiles = {"head.png","plant.jpg","test.csv","testgraph.tex","ref.bib","tutorial/"}
 

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -346,7 +346,7 @@ fontupper=\sffamily,colupper=white}
 
 也有两种类型：纯色方块和边缘描边。
 
-% \beamerdemo[1]{step11.tex}
+\beamerdemo[1]{step11.tex}
 
 \beamerdemo[1]{step12.tex}
 

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -348,7 +348,7 @@ fontupper=\sffamily,colupper=white}
 
 \beamerdemo[1]{step11.tex}
 
-\beamerdemo[1]{step12.tex}
+% \beamerdemo[1]{step12.tex}
 
 \begin{enumerate}\small
   \item \texttt{block}, \texttt{alertblock}, \texttt{exampleblock} 环境分别可以产生与主题色对应的三种盒子。

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -431,8 +431,9 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[1]{step17.tex}
 
 \begin{enumerate}\small
-  \item 使用 \texttt{\textbackslash{}logo} 设定徽标。在 \verb"usetheme" 处使用 \verb"topright" 或 \verb"bottomright" 选项指定徽标在幻灯片中显示的位置为右上角或左下角。默认情况下，\verb"max" 会将徽标显示在右下角，而 \verb"maxplus" 和 \verb"min" 会在右上角。
-  \item 可以使用自定义的徽标（或\href{run:sjtubeamerdevguide.pdf}{开发指南}第 3.4 节参见创造可变颜色徽标$^*$），但是不归 \themename 颜色系统管理$^*$，此时推荐使用亮色主题以提供亮色徽标背景。
+  \item 使用 \texttt{\textbackslash{}logo} 设定徽标。在 \verb"usetheme" 处使用 \verb"topright" 或 \verb"bottomright" 选项强制指定徽标在幻灯片中显示的位置为右上角（\verb"max"默认）或左下角（\verb"maxplus" 和 \verb"min"）。
+  \item 可以使用自定义的徽标，但是不归 \themename 颜色系统管理$^*$，此时推荐使用亮色主题以提供亮色徽标背景。
+  \item 或参见\href{run:sjtubeamerdevguide.pdf}{开发指南}第 3.4 节创造可变颜色徽标$^*$。
 \end{enumerate}
 
 \chapter{头图}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -479,7 +479,7 @@ fontupper=\sffamily,colupper=white}
     \hline
     \textbackslash{}makebottom & \textbackslash{}emph      & \textbackslash{}highlight  \\
     \textbackslash{}paragraph  & codeblock                 & \textbackslash{}stamparray \\
-    \textbackslash{}*logo      & \textbackslash{}sjtubadge & stampbox                  \\
+    \textbackslash{}*logo      & \textbackslash{}sjtubadge & stampbox                   \\
     \hline
   \end{tabular}
 \end{table}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -404,7 +404,7 @@ fontupper=\sffamily,colupper=white}
 \begin{enumerate}\small
   \item 需要加载 \texttt{pgfplots} 宏包，必要时额外加载 \texttt{pgfplotstable} 宏包以读取文件数据。可以使用 \href{https://logcreative.github.io/PGFPlotsEdt/}{PGFPlots 统计绘图编辑器} 生成上述代码。
   \item[\faExclamationTriangle] 过多的统计图会增长编译时间，不宜过多使用。
-  \item[\faInfoCircle] 现在的版本对于幻灯片内有较多的 Ti\emph{k}Z 插图有实验性的优化，当编译时采用 \verb"--shell-escape" 开关时，将会启动缓存模式。第一次编译时渲染缓存会稍慢，但是后面的编译都将会使用这一次编译的产物，就如直接添加图片一样。
+  \item[\faInfoCircle] 现在的版本对于 Ti\emph{k}Z 插图有实验性的优化，当编译采用 \verb"--shell-escape" 开关时，会启动缓存模式。第一次编译时因为需要渲染缓存会稍慢，但是后面的编译都将使用这次编译的产物，就如直接添加图片一样，就会变得快起来。
 \end{enumerate}
 
 % TODO: 以后的开发计划：Smart Diagram
@@ -431,9 +431,8 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[1]{step17.tex}
 
 \begin{enumerate}\small
-  \item 使用 \texttt{\textbackslash{}logo} 设定徽标。你可以通过使用 \verb"topright" 或 \verb"bottomright" 指定徽标在幻灯片中显示的位置为右上角或左下角。默认情况下，\verb"max" 会将徽标显示在右下角，而 \verb"maxplus" 和 \verb"min" 会将徽标显示在右上角。
-  \item 可以使用自定义的徽标，但是不归 \themename 颜色系统管理$^*$，此时推荐使用亮色主题以提供亮色徽标背景。
-  \item 如果需要创造可变颜色徽标$^*$，参阅\href{run:sjtubeamerdevguide.pdf}{开发指南}第 3.4 节。
+  \item 使用 \texttt{\textbackslash{}logo} 设定徽标。在 \verb"usetheme" 处使用 \verb"topright" 或 \verb"bottomright" 选项指定徽标在幻灯片中显示的位置为右上角或左下角。默认情况下，\verb"max" 会将徽标显示在右下角，而 \verb"maxplus" 和 \verb"min" 会在右上角。
+  \item 可以使用自定义的徽标（或\href{run:sjtubeamerdevguide.pdf}{开发指南}第 3.4 节参见创造可变颜色徽标$^*$），但是不归 \themename 颜色系统管理$^*$，此时推荐使用亮色主题以提供亮色徽标背景。
 \end{enumerate}
 
 \chapter{头图}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -346,9 +346,9 @@ fontupper=\sffamily,colupper=white}
 
 也有两种类型：纯色方块和边缘描边。
 
-\beamerdemo[1]{step11.tex}
+% \beamerdemo[1]{step11.tex}
 
-% \beamerdemo[1]{step12.tex}
+\beamerdemo[1]{step12.tex}
 
 \begin{enumerate}\small
   \item \texttt{block}, \texttt{alertblock}, \texttt{exampleblock} 环境分别可以产生与主题色对应的三种盒子。

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -479,7 +479,7 @@ fontupper=\sffamily,colupper=white}
     \hline
     \textbackslash{}makebottom & \textbackslash{}emph      & \textbackslash{}highlight  \\
     \textbackslash{}paragraph  & codeblock                 & \textbackslash{}stamparray \\
-    \textbackslash{}*logo      & \textbackslash{}sjtubadge & stampline                  \\
+    \textbackslash{}*logo      & \textbackslash{}sjtubadge & stampbox                  \\
     \hline
   \end{tabular}
 \end{table}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -404,6 +404,7 @@ fontupper=\sffamily,colupper=white}
 \begin{enumerate}\small
   \item 需要加载 \texttt{pgfplots} 宏包，必要时额外加载 \texttt{pgfplotstable} 宏包以读取文件数据。可以使用 \href{https://logcreative.github.io/PGFPlotsEdt/}{PGFPlots 统计绘图编辑器} 生成上述代码。
   \item[\faExclamationTriangle] 过多的统计图会增长编译时间，不宜过多使用。
+  \item[\faInfoCircle] 现在的版本对于幻灯片内有较多的 Ti\emph{k}Z 插图有实验性的优化，当编译时采用 \verb"--shell-escape" 开关时，将会启动缓存模式。第一次编译时渲染缓存会稍慢，但是后面的编译都将会使用这一次编译的产物，就如直接添加图片一样。
 \end{enumerate}
 
 % TODO: 以后的开发计划：Smart Diagram
@@ -430,7 +431,7 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[1]{step17.tex}
 
 \begin{enumerate}\small
-  \item 使用 \texttt{\textbackslash{}logo} 设定徽标。
+  \item 使用 \texttt{\textbackslash{}logo} 设定徽标。你可以通过使用 \verb"topright" 或 \verb"bottomright" 指定徽标在幻灯片中显示的位置为右上角或左下角。默认情况下，\verb"max" 会将徽标显示在右下角，而 \verb"maxplus" 和 \verb"min" 会将徽标显示在右上角。
   \item 可以使用自定义的徽标，但是不归 \themename 颜色系统管理$^*$，此时推荐使用亮色主题以提供亮色徽标背景。
   \item 如果需要创造可变颜色徽标$^*$，参阅\href{run:sjtubeamerdevguide.pdf}{开发指南}第 3.4 节。
 \end{enumerate}

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -33,6 +33,7 @@
 
 \usepackage{multicol}
 \usepackage{tikz}
+\usepackage{hologo}
 
 \def\fcmd#1{\paragraph{\fbox{\ttfamily #1}}}
 
@@ -142,6 +143,16 @@ and copy the corresponding generated files to the root directory.
 \subsection{Check Integration}
 
 All other scripts in the folder \verb".github/ci" could also be checked in your local machine to make sure you can pass the CI on GitHub Actions.
+
+For those who are familiar with \verb"makefile" system, the following command might be helpful to build the package under the root directory:
+
+\fcmd{make generate} This command will unpack the Doc\TeX{} files into style files and update the generated files in the root directory.
+
+\fcmd{make build} This command will build the \verb"main.tex" file.
+
+\fcmd{make build-dev} This command will go through all the tests and generate the release zip file. You could install the generated \verb".tds" file into the installing directory of your \TeX{} distribution.
+
+\fcmd{make format-dev} This command will format all the files, clear the indent. In order to improve the code quality.
 
 \clearpage
 
@@ -516,7 +527,7 @@ To be clear, \themename{} is not adapt to all kinds of compilers in the current 
                            & Windows        & *nix           \\
       pdf\LaTeX{}(C\TeX{}) & $\surd$        &                \\
       pdf\LaTeX{}(CJK)     & $\surd$        & $\surd$        \\
-      Xe\LaTeX{}           & $\diamondsuit$ & $\surd$        \\
+      \hologo{XeLaTeX}     & $\diamondsuit$ & $\surd$        \\
       Lua\LaTeX{}          & $\diamondsuit$ & $\diamondsuit$ \\
     \end{tabular}
     \vskip 3pt\moveright 1in\vbox{\hrule width3cm \vskip 3pt
@@ -524,6 +535,8 @@ To be clear, \themename{} is not adapt to all kinds of compilers in the current 
     }
   \end{center}
 \end{table}
+
+As always, we strongly recommend compiling the document through \hologo{XeLaTeX} in Mac and Linux Operating Systems, and pdf\LaTeX{} in Windows. And Lua\LaTeX{} is pretty slow with \verb"beamer" class, which is not recommended. But it has \verb"lua-visual-debug" package for developers to check the bounding box of each component to check errors.
 
 \themename{} make its effort on engine support in the following ways:
 \begin{enumerate}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/17 sjtubeamer color theme v2.1.0]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/22 sjtubeamer color theme v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/04 sjtubeamer color theme v2.0.0]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/17 sjtubeamer color theme v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/22 sjtubeamer color theme v2.1.0]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/09/25 sjtubeamer color theme v2.2.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/04 sjtubeamer font theme v2.0.0]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/17 sjtubeamer font theme v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/17 sjtubeamer font theme v2.1.0]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/22 sjtubeamer font theme v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/22 sjtubeamer font theme v2.1.0]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/09/25 sjtubeamer font theme v2.2.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -626,21 +626,6 @@
 }
 %    \end{macrocode}
 %
-% \subsubsection{Footnotes}
-%  \begin{macro}{\footnote}
-%   Define the \verb"footnote" beamer template. The format is slightly changed from the original beamer definition.
-%    \begin{macrocode}
-\defbeamertemplate*{footnote}{sjtubeamer}
-{
-  \usebeamerfont{footnote}
-  \usebeamercolor[fg]{footnote}
-  \parindent 0.5em\noindent%
-  \raggedright
-  \hbox to 1.5em{\hfil\insertfootnotemark}\insertfootnotetext\par%
-}
-%    \end{macrocode}
-%  \end{macro}
-%
 % \iffalse
 %</package>
 % \fi

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/04 sjtubeamer inner theme v2.0.0]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/17 sjtubeamer inner theme v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/22 sjtubeamer inner theme v2.1.0]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/25 sjtubeamer inner theme v2.2.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/17 sjtubeamer inner theme v2.1.0]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/09/22 sjtubeamer inner theme v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}
@@ -628,7 +628,7 @@
 %
 % \subsubsection{Footnotes}
 %  \begin{macro}{\footnote}
-%   Define the \verb"footline" beamer template. The format is slightly changed from the original beamer definition.
+%   Define the \verb"footnote" beamer template. The format is slightly changed from the original beamer definition.
 %    \begin{macrocode}
 \defbeamertemplate*{footnote}{sjtubeamer}
 {

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -321,7 +321,7 @@
 %  \begin{macro}{\partpage}
 %   Define the \verb"part page" beamer template.
 %    \begin{macrocode}
-\defbeamertemplate*{part page}{sjtubeamermin}[1][]
+\defbeamertemplate*{part page}{sjtubeamer}[1][]
 {
   \vfill
   \vskip 8pt
@@ -389,7 +389,7 @@
 %  \begin{macro}{\sectionpage}
 %   Define the \verb"section page" beamer template.
 %    \begin{macrocode}
-\defbeamertemplate*{section page}{sjtubeamermin}[1][]
+\defbeamertemplate*{section page}{sjtubeamer}[1][]
 {
   \vfill
   \begingroup
@@ -403,7 +403,7 @@
 %  \begin{macro}{\subsectionpage}
 %   Define the \verb"subection page" beamer template.
 %    \begin{macrocode}
-\defbeamertemplate*{subsection page}{sjtubeamermin}[1][]
+\defbeamertemplate*{subsection page}{sjtubeamer}[1][]
 {
   \vfill
   \begingroup

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -472,6 +472,7 @@
 %
 % \begin{macro}{stampbox}
 %   Make a stampbox border, which is a decoration advice from SJTU VI. It has the dependency on \verb"stampline" from \verb"sjtuvi" package.
+%   TODO: if you insert the \verb"stampbox" inside the document, the error will occurred. The externalize library is really not that handy when comes to these edge scenarios. Consider to solve the problem entirely, or try to shelter this, or disable this feature.
 %    \begin{macrocode}
 \newtcolorbox{stampbox}[1][cprimary]{%
   capture=hbox,

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -229,11 +229,11 @@
 %
 %  \begin{macro}{\coverpage}
 %  Common command for \verb"\titlepage" and \verb"\bottompage". Disable externalization for generating title page and bottom page, locally.
+%  Since the definition on \verb"\sjtubeamer@logocolor" is defined in a group, the stack is not necessary to store the value.
 %    \begin{macrocode}
 \def\coverpage#1{
   {
     \tikzset{external/export=false}
-    \let\oldlogocolor=\sjtubeamer@logocolor%
     \ifdim\beamer@sidebarwidth=0pt %
       \usebeamertemplate*{#1}
     \else
@@ -241,7 +241,6 @@
         \usebeamertemplate*{#1}
       }
     \fi
-    \let\sjtubeamer@logocolor=\oldlogocolor%
   }
 }
 %    \end{macrocode}
@@ -257,15 +256,16 @@
 %  \end{macro}
 %
 %  \begin{macro}{\maketitle}
-%  Patch make title command. It will receive an optional argument for switching different type of title page. After making the current title page, the previous setting should be restored.
+%  Patch make title command. It will receive an optional argument for switching different type of title page. The set on beamer template is inside a group, so the setting is locale.
 %    \begin{macrocode}
 \renewcommand{\maketitle}[1][\sjtubeamer@inner@cover]{
-  \setbeamertemplate{title page}[#1]
-  \ifbeamer@inframe\titlepage\else
-    \begin{frame}[plain]
-      \titlepage
-    \end{frame}\fi
-  \setbeamertemplate{title page}[\sjtubeamer@inner@cover]
+  {
+    \setbeamertemplate{title page}[#1]
+    \ifbeamer@inframe\titlepage\else
+      \begin{frame}[plain]
+        \titlepage
+      \end{frame}\fi
+  }
 }
 %    \end{macrocode}
 %  \end{macro}
@@ -294,12 +294,13 @@
 %   Make the bottom page. Not a built-in command.
 %    \begin{macrocode}
 \newcommand{\makebottom}[1][\sjtubeamer@inner@cover]{
-  \setbeamertemplate{bottom page}[#1][\bottomthanks]
-  \ifbeamer@inframe\bottompage\else
-    \begin{frame}[plain]
-      \bottompage
-    \end{frame}\fi
-  \setbeamertemplate{bottom page}[\sjtubeamer@inner@cover][\bottomthanks]
+  {
+    \setbeamertemplate{bottom page}[#1][\bottomthanks]
+    \ifbeamer@inframe\bottompage\else
+      \begin{frame}[plain]
+        \bottompage
+      \end{frame}\fi
+  }
 }
 %    \end{macrocode}
 %  \end{macro}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -129,11 +129,13 @@
 %   \subsubsection{Load Packages}
 %
 %   Introduce the library from tcolorbox to make code blocks.
-%   \verb"listingsutf8" is used to receive UTF-8 input.
+%   \verb"listingsutf8" is used to receive UTF-8 input. 
+%   The global set on shield externalize will prevent tcolorbox from externalizing. 
 %    \begin{macrocode}
 \RequirePackage{tcolorbox}
 \tcbuselibrary{skins}
 \tcbuselibrary{listingsutf8}
+\tcbset{shield externalize}
 %    \end{macrocode}
 %
 % \subsubsection{Title Page \& Bottom Page}
@@ -472,7 +474,6 @@
 %
 % \begin{macro}{stampbox}
 %   Make a stampbox border, which is a decoration advice from SJTU VI. It has the dependency on \verb"stampline" from \verb"sjtuvi" package.
-%   TODO: if you insert the \verb"stampbox" inside the document, the error will occurred. The externalize library is really not that handy when comes to these edge scenarios. Consider to solve the problem entirely, or try to shelter this, or disable this feature.
 %    \begin{macrocode}
 \newtcolorbox{stampbox}[1][cprimary]{%
   capture=hbox,

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -161,21 +161,13 @@
 %  \end{macro}
 %
 %  \begin{macro}{\bgcenterbox}
-%   Define a command for USERS to make a centered background box easily.
+%   Define a command for USERS to make a centered background box easily. Move the defination on \verb"\sjtubeamer@logocolor" to the inner environment, to avoid the shift on centering. And since the definition has already been moved into the inner group, the definition here is \emph{locale} and no more stack saving is needed.
 %    \begin{macrocode}
 \newcommand{\bgcenterbox}[1]{
-  \let\oldlogocolor=\sjtubeamer@logocolor%
-  \def\sjtubeamer@logocolor{cprimary!50}
-  \vbox to \paperheight{
-    \vfil
-    \hbox to \paperwidth{
-      \hfil
-      #1
-      \hfil
-    }
-    \vfil
+  \parbox[c][1.1\paperheight][c]{\paperwidth}{
+    \def\sjtubeamer@logocolor{cprimary!50}
+    \centering\resizebox{\paperwidth}{!}{#1}
   }
-  \let\sjtubeamer@logocolor=\oldlogocolor%
 }
 %    \end{macrocode}
 %  \end{macro}
@@ -197,9 +189,7 @@
     \usebeamercolor{palatte primary}
     \titlegraphic{\sjtubg[opacity=0.2]}
     \setbeamertemplate{background}
-    {
-      \parbox[c][1.1\paperheight][c]{\paperwidth}{\centering\resizebox{\paperwidth}{!}{\sjtubg[cprimary!50,opacity=0.2]}}
-    }
+    {\bgcenterbox{\sjtubg[cprimary!50,opacity=0.2]}}
   \else
 %</max>
 %<*min>
@@ -628,7 +618,8 @@
         \Hy@Warning{%
           Option `#1' has already been used,\MessageBreak
           setting the option has no effect%
-        }\fi%
+        }
+      \fi%
     \fi%
   }
 }

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -235,19 +235,31 @@
 \beamer@sidebarwidth=0pt
 %    \end{macrocode}
 %
+%  \begin{macro}{\coverpage}
+%  Common command for \verb"\titlepage" and \verb"\bottompage". Disable externalization for generating title page and bottom page, locally.
+%    \begin{macrocode}
+\def\coverpage#1{
+  {
+    \tikzset{external/export=false}
+    \let\oldlogocolor=\sjtubeamer@logocolor%
+    \ifdim\beamer@sidebarwidth=0pt %
+      \usebeamertemplate*{#1}
+    \else
+      \hspace*{-0.5\beamer@sidebarwidth}\parbox[t]{\textwidth}{
+        \usebeamertemplate*{#1}
+      }
+    \fi
+    \let\sjtubeamer@logocolor=\oldlogocolor%
+  }
+}
+%    \end{macrocode}
+%  \end{macro}
+%
 %  \begin{macro}{\titlepage}
 %   Call the title page template to make a title page. This is a patch for the original \verb"\titlepage" command, to fit with the logo color system.
 %    \begin{macrocode}
 \def\titlepage{
-  \let\oldlogocolor=\sjtubeamer@logocolor%
-  \ifdim\beamer@sidebarwidth=0pt %
-    \usebeamertemplate*{title page}
-  \else
-    \hspace*{-0.5\beamer@sidebarwidth}\parbox[t]{\textwidth}{
-      \usebeamertemplate*{title page}
-    }
-  \fi
-  \let\sjtubeamer@logocolor=\oldlogocolor%
+  \coverpage{title page}
 }
 %    \end{macrocode}
 %  \end{macro}
@@ -270,15 +282,7 @@
 %   Call the bottom page template to make a bottom page.
 %    \begin{macrocode}
 \def\bottompage{
-  \let\oldlogocolor=\sjtubeamer@logocolor%
-  \ifdim\beamer@sidebarwidth=0pt %
-    \usebeamertemplate*{bottom page}
-  \else
-    \hspace*{-0.5\beamer@sidebarwidth}\parbox[t]{\textwidth}{
-      \usebeamertemplate*{bottom page}
-    }
-  \fi
-  \let\sjtubeamer@logocolor=\oldlogocolor%
+  \coverpage{bottom page}
 }
 %    \end{macrocode}
 %  \end{macro}
@@ -632,7 +636,7 @@
 %  \begin{macro}{\footnote}
 %   Define the \verb"footline" beamer template. The format is slightly changed from the original beamer definition.
 %    \begin{macrocode}
-\defbeamertemplate*{footnote}{sjtubeamermin}
+\defbeamertemplate*{footnote}{sjtubeamer}
 {
   \usebeamerfont{footnote}
   \usebeamercolor[fg]{footnote}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/22 sjtubeamer outer theme v2.1.0]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/25 sjtubeamer outer theme v2.2.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -159,6 +159,7 @@
 \addtobeamertemplate{footline}{
   \hfill%
   \usebeamertemplate***{navigation symbols}%
+  \llap{\raisebox{1pc}[0pt][0pt]{\insertouterlogo}}
   \hspace*{0.1cm}\par
   \vskip 4pt
 }{}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -99,7 +99,7 @@
     \begingroup
     \ifx\insertframesubtitle\@empty\vskip-2.5ex%
     \else\vskip-3.5ex\fi%
-    {\resizebox{!}{0.7cm}{\insertlogo}}\hspace*{2ex}%
+    {\resizebox{!}{0.7cm}{\insertlogo}}\hspace*{5pt}%
     \endgroup%
     \ifx\insertframesubtitle\@empty%
     \else\vskip0.5ex\fi%
@@ -108,7 +108,7 @@
 }
 %    \end{macrocode}
 %
-%  \subsubsection{Execute Outer theme}
+%  \subsubsection{Execute Outer Theme}
 %
 % Use the built-in outer templates. If you want to take special care about one outer theme, please add a condition test on that theme. Otherwise, it will use the default configuration of the corresponding built-in outer theme.
 %    \begin{macrocode}
@@ -119,7 +119,7 @@
 %    \begin{macrocode}
 \else\if\EqualOption{outer}{nav}{sidebar}
     \useoutertheme{sidebar}
-    \setbeamertemplate{frametitle}{sidebar theme}
+    \setbeamertemplate{frametitle}[sidebar theme]
 %    \end{macrocode}
 % If it is other theme, change the beamercolor to fit smooth* theme.
 %    \begin{macrocode}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -53,10 +53,8 @@
 %
 % \begin{macro}{\sjtubeamer@outer@logopos}
 %    \begin{macrocode}
-\DefineOption{outer}{logopos}{topleft}
 \DefineOption{outer}{logopos}{topright}
 \DefineOption{outer}{logopos}{bottomright}
-\DefineOption{outer}{logopos}{bottomleft}
 \ExecuteOptionsBeamer{bottomright}
 %    \end{macrocode}
 % \end{macro}
@@ -70,57 +68,10 @@
 \beamer@compresstrue
 %    \end{macrocode}
 %
-% \subsubsection{Outer logo}
-% Insert the outer logo with 0.7cm height. \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input.
-\def\insertouterlogo{
-  \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}
-}
-%
 % \subsubsection{Frame Title}
 %
-%  \begin{macro}{\inserttitlesubtitle}
-%   Helper macro for frametitle.
+%   Define the beamer template \verb"frametitle" to add a logo in the right of the frametitle (top right corner) for \verb"topright" option. If it is not \verb"topright" option, then the default \verb"frametitle" template is used.
 %    \begin{macrocode}
-\def\inserttitlesubtitle#1{
-  \ifx\insertframesubtitle\@empty\vskip-2pt%
-  \else\vskip-1ex\fi%
-  \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
-  \strut\insertframetitle\strut\par%
-  {%
-    \ifx\insertframesubtitle\@empty%
-    \else%
-    {
-      \usebeamerfont{framesubtitle}
-      \usebeamercolor[fg]{framesubtitle}
-      \strut\insertframesubtitle\strut\par
-    }%
-    \fi
-  }%
-  \vskip-1ex%
-}
-%    \end{macrocode}
-%  \end{macro}
-%
-%   Define the beamer template \verb"frametitle" to add a logo in the right of the frametitle (top right corner).
-%    \begin{macrocode}
-\if\EqualOption{outer}{logopos}{topleft}
-  \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
-  {%
-  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
-    \@tempdima=\textwidth%
-    \advance\@tempdima by\beamer@leftmargin%
-    \advance\@tempdima by\beamer@rightmargin%
-    \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
-      \hbox{
-        \insertouterlogo
-        \vbox{
-          \inserttitlesubtitle{#1}
-        }
-      }
-      \if@tempswa\else\vskip-.3cm\fi%
-    \end{beamercolorbox}%
-  }
-\fi
 \if\EqualOption{outer}{logopos}{topright}
   \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
   {%
@@ -129,12 +80,33 @@
     \advance\@tempdima by\beamer@leftmargin%
     \advance\@tempdima by\beamer@rightmargin%
     \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
-      \inserttitlesubtitle{#1}
+      \begingroup
+      \usebeamerfont{frametitle}
+      \vbox{}
+      \ifx\insertframesubtitle\@empty\vskip-2pt%
+      \else\vskip-1ex\fi%
+      \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
+      \strut\insertframetitle\strut\par%
+      {%
+        \ifx\insertframesubtitle\@empty%
+        \else%
+        {
+          \usebeamerfont{framesubtitle}
+          \usebeamercolor[fg]{framesubtitle}
+          \strut\insertframesubtitle\strut\par
+        }%
+        \fi
+      }%
+      \vskip-1ex%
+      \endgroup%
       \raggedleft%
       \begingroup
       \ifx\insertframesubtitle\@empty\vskip-2.5ex%
       \else\vskip-3.5ex\fi%
-      \insertouterlogo\hspace*{5pt}%
+%    \end{macrocode}
+% Insert the outer logo with 0.7cm height. \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input. The calculation is fixed for a 0.7cm height logo placeholder.
+%    \begin{macrocode}
+      \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}\hspace*{5pt}%
       \endgroup%
       \ifx\insertframesubtitle\@empty%
       \else\vskip0.5ex\fi%
@@ -194,21 +166,14 @@
 }
 %    \end{macrocode}
 %
-%  Append the navigation to the footline to avoid the collision with the navigation symbols. This will clear the original placeholder for the logo -- place it elsewhere.
+%  Append the navigation to the footline to avoid the collision with the navigation symbols. This will clear the original placeholder for the logo -- place it elsewhere. However, in the \verb"bottomright" mode, the logo size is not constrainted.
+%  The code is a bit redundent since we don't want it to check the condition every time making a bottom bar.
 %    \begin{macrocode}
-\if\EqualOption{outer}{logopos}{bottomleft}
-  \addtobeamertemplate{footline}{
-    \rlap{\raisebox{3ex}[0pt][0pt]{\insertouterlogo}}
-    \hfill%
-    \usebeamertemplate***{navigation symbols}%
-    \hspace*{0.1cm}\par
-    \vskip 4pt
-  }{}
-\else\if\EqualOption{outer}{logopos}{bottomright}
+\if\EqualOption{outer}{logopos}{bottomright}
   \addtobeamertemplate{footline}{
     \hfill%
     \usebeamertemplate***{navigation symbols}%
-    \llap{\raisebox{1pc}[0pt][0pt]{\insertouterlogo}}
+    \llap{\raisebox{1pc}[0pt][0pt]{\insertlogo}}
     \hspace*{0.1cm}\par
     \vskip 4pt
   }{}
@@ -219,7 +184,7 @@
     \hspace*{0.1cm}\par
     \vskip 4pt
   }{}
-\fi\fi
+\fi
 %    \end{macrocode}
 %
 % And set the page number template to none.

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/04 sjtubeamer outer theme v2.0.0]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/17 sjtubeamer outer theme v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -157,6 +157,7 @@
 %  Append the navigation to the footline to avoid the collision with the navigation symbols. This will clear the original placeholder for the logo -- place it elsewhere.
 %    \begin{macrocode}
 \addtobeamertemplate{footline}{
+  \rlap{\raisebox{3ex}[0pt][0pt]{\insertouterlogo}}
   \hfill%
   \usebeamertemplate***{navigation symbols}%
   \llap{\raisebox{1pc}[0pt][0pt]{\insertouterlogo}}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -87,7 +87,10 @@
 %
 % \subsubsection{Bottombar}
 %
-% TODO: move the logo position.
+%   Clear the original definition of sidebar first. Then append the page info to the footline, which could avoid collision on footnote.
+%    \begin{macrocode} 
+\setbeamertemplate{sidebar right}{}
+%    \end{macrocode}
 %
 % Add page number to the toolbox.
 %    \begin{macrocode}
@@ -103,6 +106,17 @@
   }
 }
 %    \end{macrocode}
+%
+%  Append the navigation to the footline to avoid the collision with the navigation symbols. This will clear the original placeholder for the logo -- place it elsewhere.
+%    \begin{macrocode}
+\addtobeamertemplate{footline}{
+  \hfill%
+  \usebeamertemplate***{navigation symbols}%
+  \hspace*{0.1cm}\par
+  \vskip 4pt
+}{}
+%    \end{macrocode}
+%
 % And set the page number template to none.
 %    \begin{macrocode}
 \setbeamertemplate{page number in head/foot}{}
@@ -110,7 +124,7 @@
 %
 %
 % \iffalse
-% </package>
+%</package>
 % \fi
 % \Finale
 \endinput

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -59,6 +59,7 @@
 %    \begin{macrocode}
 \beamer@compresstrue
 %    \end{macrocode}
+%
 % \subsubsection{Frame Title}
 %
 %   Define the beamer template \verb"frametitle" to add a logo in the right of the frametitle (top right corner).
@@ -93,13 +94,13 @@
     \vskip-1ex%
     \endgroup%
 %    \end{macrocode}
-%   Add the logo to the upper right corner. It will be scaled to a 0.7cm height one by using \verb"\resizebox".
+%   Add the logo to the upper right corner. It will be scaled to a 0.7cm height one by using \verb"\resizebox". \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input.
 %    \begin{macrocode}
     \raggedleft%
     \begingroup
     \ifx\insertframesubtitle\@empty\vskip-2.5ex%
     \else\vskip-3.5ex\fi%
-    {\resizebox{!}{0.7cm}{\insertlogo}}\hspace*{5pt}%
+    {\resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}}\hspace*{5pt}%
     \endgroup%
     \ifx\insertframesubtitle\@empty%
     \else\vskip0.5ex\fi%

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -66,41 +66,36 @@
 %    \begin{macrocode}
 \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
 {%
-  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+\ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
   \@tempdima=\textwidth%
   \advance\@tempdima by\beamer@leftmargin%
   \advance\@tempdima by\beamer@rightmargin%
   \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
-    \begingroup
-    \usebeamerfont{frametitle}
-%    \end{macrocode}
-%   Insert title and subtitle and make spacing depend on the existence of subtitle.
-%    \begin{macrocode}
-    \vbox{}
-    \ifx\insertframesubtitle\@empty\vskip-2pt%
-    \else\vskip-1ex\fi%
-    \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
-    \strut\insertframetitle\strut\par%
-    {%
-      \ifx\insertframesubtitle\@empty%
-      \else%
-      {
-        \usebeamerfont{framesubtitle}
-        \usebeamercolor[fg]{framesubtitle}
-        \strut\insertframesubtitle\strut\par
-      }%
-      \fi
-    }%
-    \vskip-1ex%
-    \endgroup%
-%    \end{macrocode}
-%   Add the logo to the upper right corner. It will be scaled to a 0.7cm height one by using \verb"\resizebox". \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input.
-%    \begin{macrocode}
+    \hbox{
+      \insertouterlogo
+      \vbox{
+        \ifx\insertframesubtitle\@empty\vskip-2pt%
+        \else\vskip-1ex\fi%
+        \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
+        \strut\insertframetitle\strut\par%
+        {%
+          \ifx\insertframesubtitle\@empty%
+          \else%
+          {
+            \usebeamerfont{framesubtitle}
+            \usebeamercolor[fg]{framesubtitle}
+            \strut\insertframesubtitle\strut\par
+          }%
+          \fi
+        }%
+        \vskip-1ex%
+      }
+    }
     \raggedleft%
     \begingroup
     \ifx\insertframesubtitle\@empty\vskip-2.5ex%
     \else\vskip-3.5ex\fi%
-    {\resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}}\hspace*{5pt}%
+    \insertouterlogo\hspace*{5pt}%
     \endgroup%
     \ifx\insertframesubtitle\@empty%
     \else\vskip0.5ex\fi%

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -51,6 +51,16 @@
 %    \end{macrocode}
 %  \end{macro}
 %
+% \begin{macro}{\sjtubeamer@outer@logopos}
+%    \begin{macrocode}
+\DefineOption{outer}{logopos}{topleft}
+\DefineOption{outer}{logopos}{topright}
+\DefineOption{outer}{logopos}{bottomright}
+\DefineOption{outer}{logopos}{bottomleft}
+\ExecuteOptionsBeamer{bottomright}
+%    \end{macrocode}
+% \end{macro}
+%
 %    \begin{macrocode}
 \ProcessOptionsBeamer
 %    \end{macrocode}
@@ -59,6 +69,12 @@
 %    \begin{macrocode}
 \beamer@compresstrue
 %    \end{macrocode}
+%
+% \subsubsection{Outer logo}
+% Insert the outer logo with 0.7cm height. \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input.
+\def\insertouterlogo{
+  \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}
+}
 %
 % \subsubsection{Frame Title}
 %
@@ -72,7 +88,9 @@
   \advance\@tempdima by\beamer@rightmargin%
   \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
     \hbox{
-      \insertouterlogo
+      \if\EqualOption{outer}{logopos}{topleft}
+        \insertouterlogo
+      \fi
       \vbox{
         \ifx\insertframesubtitle\@empty\vskip-2pt%
         \else\vskip-1ex\fi%
@@ -91,14 +109,16 @@
         \vskip-1ex%
       }
     }
-    \raggedleft%
-    \begingroup
-    \ifx\insertframesubtitle\@empty\vskip-2.5ex%
-    \else\vskip-3.5ex\fi%
-    \insertouterlogo\hspace*{5pt}%
-    \endgroup%
-    \ifx\insertframesubtitle\@empty%
-    \else\vskip0.5ex\fi%
+    \if\EqualOption{outer}{logopos}{topright}
+      \raggedleft%
+      \begingroup
+      \ifx\insertframesubtitle\@empty\vskip-2.5ex%
+      \else\vskip-3.5ex\fi%
+      \insertouterlogo\hspace*{5pt}%
+      \endgroup%
+      \ifx\insertframesubtitle\@empty%
+      \else\vskip0.5ex\fi%
+    \fi
     \if@tempswa\else\vskip-.3cm\fi%
   \end{beamercolorbox}%
 }
@@ -157,10 +177,14 @@
 %  Append the navigation to the footline to avoid the collision with the navigation symbols. This will clear the original placeholder for the logo -- place it elsewhere.
 %    \begin{macrocode}
 \addtobeamertemplate{footline}{
-  \rlap{\raisebox{3ex}[0pt][0pt]{\insertouterlogo}}
+  \if\EqualOption{outer}{logopos}{bottomleft}
+    \rlap{\raisebox{3ex}[0pt][0pt]{\insertouterlogo}}
+  \fi
   \hfill%
   \usebeamertemplate***{navigation symbols}%
-  \llap{\raisebox{1pc}[0pt][0pt]{\insertouterlogo}}
+  \if\EqualOption{outer}{logopos}{bottomright}
+    \llap{\raisebox{1pc}[0pt][0pt]{\insertouterlogo}}
+  \fi
   \hspace*{0.1cm}\par
   \vskip 4pt
 }{}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -78,38 +78,58 @@
 %
 % \subsubsection{Frame Title}
 %
+%  \begin{macro}{\inserttitlesubtitle}
+%   Helper macro for frametitle.
+%    \begin{macrocode}
+\def\inserttitlesubtitle#1{
+  \ifx\insertframesubtitle\@empty\vskip-2pt%
+  \else\vskip-1ex\fi%
+  \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
+  \strut\insertframetitle\strut\par%
+  {%
+    \ifx\insertframesubtitle\@empty%
+    \else%
+    {
+      \usebeamerfont{framesubtitle}
+      \usebeamercolor[fg]{framesubtitle}
+      \strut\insertframesubtitle\strut\par
+    }%
+    \fi
+  }%
+  \vskip-1ex%
+}
+%    \end{macrocode}
+%  \end{macro}
+%
 %   Define the beamer template \verb"frametitle" to add a logo in the right of the frametitle (top right corner).
 %    \begin{macrocode}
-\defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
-{%
-\ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
-  \@tempdima=\textwidth%
-  \advance\@tempdima by\beamer@leftmargin%
-  \advance\@tempdima by\beamer@rightmargin%
-  \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
-    \hbox{
-      \if\EqualOption{outer}{logopos}{topleft}
+\if\EqualOption{outer}{logopos}{topleft}
+  \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+  {%
+  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+    \@tempdima=\textwidth%
+    \advance\@tempdima by\beamer@leftmargin%
+    \advance\@tempdima by\beamer@rightmargin%
+    \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+      \hbox{
         \insertouterlogo
-      \fi
-      \vbox{
-        \ifx\insertframesubtitle\@empty\vskip-2pt%
-        \else\vskip-1ex\fi%
-        \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
-        \strut\insertframetitle\strut\par%
-        {%
-          \ifx\insertframesubtitle\@empty%
-          \else%
-          {
-            \usebeamerfont{framesubtitle}
-            \usebeamercolor[fg]{framesubtitle}
-            \strut\insertframesubtitle\strut\par
-          }%
-          \fi
-        }%
-        \vskip-1ex%
+        \vbox{
+          \inserttitlesubtitle{#1}
+        }
       }
-    }
-    \if\EqualOption{outer}{logopos}{topright}
+      \if@tempswa\else\vskip-.3cm\fi%
+    \end{beamercolorbox}%
+  }
+\fi
+\if\EqualOption{outer}{logopos}{topright}
+  \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+  {%
+  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+    \@tempdima=\textwidth%
+    \advance\@tempdima by\beamer@leftmargin%
+    \advance\@tempdima by\beamer@rightmargin%
+    \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+      \inserttitlesubtitle{#1}
       \raggedleft%
       \begingroup
       \ifx\insertframesubtitle\@empty\vskip-2.5ex%
@@ -118,10 +138,10 @@
       \endgroup%
       \ifx\insertframesubtitle\@empty%
       \else\vskip0.5ex\fi%
-    \fi
-    \if@tempswa\else\vskip-.3cm\fi%
-  \end{beamercolorbox}%
-}
+      \if@tempswa\else\vskip-.3cm\fi%
+    \end{beamercolorbox}%
+  }
+\fi
 %    \end{macrocode}
 %
 %  \subsubsection{Execute Outer Theme}
@@ -176,18 +196,30 @@
 %
 %  Append the navigation to the footline to avoid the collision with the navigation symbols. This will clear the original placeholder for the logo -- place it elsewhere.
 %    \begin{macrocode}
-\addtobeamertemplate{footline}{
-  \if\EqualOption{outer}{logopos}{bottomleft}
+\if\EqualOption{outer}{logopos}{bottomleft}
+  \addtobeamertemplate{footline}{
     \rlap{\raisebox{3ex}[0pt][0pt]{\insertouterlogo}}
-  \fi
-  \hfill%
-  \usebeamertemplate***{navigation symbols}%
-  \if\EqualOption{outer}{logopos}{bottomright}
+    \hfill%
+    \usebeamertemplate***{navigation symbols}%
+    \hspace*{0.1cm}\par
+    \vskip 4pt
+  }{}
+\else\if\EqualOption{outer}{logopos}{bottomright}
+  \addtobeamertemplate{footline}{
+    \hfill%
+    \usebeamertemplate***{navigation symbols}%
     \llap{\raisebox{1pc}[0pt][0pt]{\insertouterlogo}}
-  \fi
-  \hspace*{0.1cm}\par
-  \vskip 4pt
-}{}
+    \hspace*{0.1cm}\par
+    \vskip 4pt
+  }{}
+\else
+  \addtobeamertemplate{footline}{
+    \hfill%
+    \usebeamertemplate***{navigation symbols}%
+    \hspace*{0.1cm}\par
+    \vskip 4pt
+  }{}
+\fi\fi
 %    \end{macrocode}
 %
 % And set the page number template to none.

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -59,16 +59,67 @@
 %    \begin{macrocode}
 \beamer@compresstrue
 %    \end{macrocode}
+% \subsubsection{Frame Title}
+%
+%   Define the beamer template \verb"frametitle" to add a logo in the right of the frametitle (top right corner).
+%    \begin{macrocode}
+\defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+{%
+  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+  \@tempdima=\textwidth%
+  \advance\@tempdima by\beamer@leftmargin%
+  \advance\@tempdima by\beamer@rightmargin%
+  \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+    \begingroup
+    \usebeamerfont{frametitle}
+%    \end{macrocode}
+%   Insert title and subtitle and make spacing depend on the existence of subtitle.
+%    \begin{macrocode}
+    \vbox{}
+    \ifx\insertframesubtitle\@empty\vskip-2pt%
+    \else\vskip-1ex\fi%
+    \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
+    \strut\insertframetitle\strut\par%
+    {%
+      \ifx\insertframesubtitle\@empty%
+      \else%
+      {
+        \usebeamerfont{framesubtitle}
+        \usebeamercolor[fg]{framesubtitle}
+        \strut\insertframesubtitle\strut\par
+      }%
+      \fi
+    }%
+    \vskip-1ex%
+    \endgroup%
+%    \end{macrocode}
+%   Add the logo to the upper right corner. It will be scaled to a 0.7cm height one by using \verb"\resizebox".
+%    \begin{macrocode}
+    \raggedleft%
+    \begingroup
+    \ifx\insertframesubtitle\@empty\vskip-2.5ex%
+    \else\vskip-3.5ex\fi%
+    {\resizebox{!}{0.7cm}{\insertlogo}}\hspace*{2ex}%
+    \endgroup%
+    \ifx\insertframesubtitle\@empty%
+    \else\vskip0.5ex\fi%
+    \if@tempswa\else\vskip-.3cm\fi%
+  \end{beamercolorbox}%
+}
+%    \end{macrocode}
+%
+%  \subsubsection{Execute Outer theme}
 %
 % Use the built-in outer templates. If you want to take special care about one outer theme, please add a condition test on that theme. Otherwise, it will use the default configuration of the corresponding built-in outer theme.
 %    \begin{macrocode}
 \if\EqualOption{outer}{nav}{miniframes}
   \useoutertheme[footline=institutetitle]{miniframes}
 %    \end{macrocode}
-% Sidebar.
+% Sidebar. Use the default template for \verb"frametitle" in sidebar, since there has already been a logo in the top left corner.
 %    \begin{macrocode}
 \else\if\EqualOption{outer}{nav}{sidebar}
     \useoutertheme{sidebar}
+    \setbeamertemplate{frametitle}{sidebar theme}
 %    \end{macrocode}
 % If it is other theme, change the beamercolor to fit smooth* theme.
 %    \begin{macrocode}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/17 sjtubeamer outer theme v2.1.0]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/09/22 sjtubeamer outer theme v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -70,48 +70,53 @@
 %
 % \subsubsection{Frame Title}
 %
+%
 %   Define the beamer template \verb"frametitle" to add a logo in the right of the frametitle (top right corner) for \verb"topright" option. If it is not \verb"topright" option, then the default \verb"frametitle" template is used.
+%
+%   \verb"smoothbars", \verb"smoothtree" and \verb"shadow" theme use a different frame title insertion mechanism so that the redefinition on \verb"frametitle" should be done just after the document starts. This overwrites the original definition of those outer theme and may cause a certain degree of style lost.
 %    \begin{macrocode}
 \if\EqualOption{outer}{logopos}{topright}
-  \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
-  {%
-  \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
-    \@tempdima=\textwidth%
-    \advance\@tempdima by\beamer@leftmargin%
-    \advance\@tempdima by\beamer@rightmargin%
-    \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
-      \begingroup
-      \usebeamerfont{frametitle}
-      \vbox{}
-      \ifx\insertframesubtitle\@empty\vskip-2pt%
-      \else\vskip-1ex\fi%
-      \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
-      \strut\insertframetitle\strut\par%
-      {%
-        \ifx\insertframesubtitle\@empty%
-        \else%
-        {
-          \usebeamerfont{framesubtitle}
-          \usebeamercolor[fg]{framesubtitle}
-          \strut\insertframesubtitle\strut\par
+  \AtBeginDocument{
+    \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+    {%
+    \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+      \@tempdima=\textwidth%
+      \advance\@tempdima by\beamer@leftmargin%
+      \advance\@tempdima by\beamer@rightmargin%
+      \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+        \begingroup
+        \usebeamerfont{frametitle}
+        \vbox{}
+        \ifx\insertframesubtitle\@empty\vskip-2pt%
+        \else\vskip-1ex\fi%
+        \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
+        \strut\insertframetitle\strut\par%
+        {%
+          \ifx\insertframesubtitle\@empty%
+          \else%
+          {
+            \usebeamerfont{framesubtitle}
+            \usebeamercolor[fg]{framesubtitle}
+            \strut\insertframesubtitle\strut\par
+          }%
+          \fi
         }%
-        \fi
-      }%
-      \vskip-1ex%
-      \endgroup%
-      \raggedleft%
-      \begingroup
-      \ifx\insertframesubtitle\@empty\vskip-2.5ex%
-      \else\vskip-3.5ex\fi%
+        \vskip-1ex%
+        \endgroup%
+        \raggedleft%
+        \begingroup
+        \ifx\insertframesubtitle\@empty\vskip-2.5ex%
+        \else\vskip-3.5ex\fi%
 %    \end{macrocode}
 % Insert the outer logo with 0.7cm height. \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input. The calculation is fixed for a 0.7cm height logo placeholder.
 %    \begin{macrocode}
-      \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}\hspace*{5pt}%
-      \endgroup%
-      \ifx\insertframesubtitle\@empty%
-      \else\vskip0.5ex\fi%
-      \if@tempswa\else\vskip-.3cm\fi%
-    \end{beamercolorbox}%
+        \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}\hspace*{5pt}%
+        \endgroup%
+        \ifx\insertframesubtitle\@empty%
+        \else\vskip0.5ex\fi%
+        \if@tempswa\else\vskip-.3cm\fi%
+      \end{beamercolorbox}%
+    }
   }
 \fi
 %    \end{macrocode}
@@ -127,7 +132,9 @@
 %    \begin{macrocode}
 \else\if\EqualOption{outer}{nav}{sidebar}
     \useoutertheme{sidebar}
-    \setbeamertemplate{frametitle}[sidebar theme]
+    \AtBeginDocument{
+      \setbeamertemplate{frametitle}[sidebar theme]
+    }
 %    \end{macrocode}
 % If it is other theme, change the beamercolor to fit smooth* theme.
 %    \begin{macrocode}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -67,16 +67,21 @@
 %   \end{itemize}
 %    \begin{macrocode}
 %<*maxplus>
-\DeclareOptionBeamer{maxplus}{\def\sjtubeamer@cover{maxplus}}
+\DeclareOptionBeamer{maxplus}{
+  \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topleft}}
 %</maxplus>
 %<*max>
-\DeclareOptionBeamer{max}{\def\sjtubeamer@cover{max}}
+\DeclareOptionBeamer{max}{
+  \def\sjtubeamer@cover{max}\def\sjtubeamer@logopos{bottomright}}
 %</max>
 %<*min>
-\DeclareOptionBeamer{min}{\def\sjtubeamer@cover{min}}
+\DeclareOptionBeamer{min}{
+  \def\sjtubeamer@cover{min}\def\sjtubeamer@logopos{topright}}
 %</min>
 %<*my>
-\DeclareOptionBeamer{my}{\def\sjtubeamer@cover{my}} % reserved for customization
+\DeclareOptionBeamer{my}{
+  \def\sjtubeamer@cover{my}\def\sjtubeamer@logopos{bottomleft}}
+    % reserved for customization
 %</my>
 %    \end{macrocode}
 %   $\rightarrow$ Next, declare the initial configuration.
@@ -149,6 +154,16 @@
 %    \end{macrocode}
 %  \end{macro}
 %
+%  \begin{macro}{\sjtubeamer@logopos}
+%   Choose the override outer logo position. No default option will get executed since it has already been executed by the selection of \verb"\sjtubeamer@cover".
+%    \begin{macrocode}
+\DeclareOptionBeamer{topleft}{\def\sjtubeamer@logopos{topleft}}
+\DeclareOptionBeamer{topright}{\def\sjtubeamer@logopos{topright}}
+\DeclareOptionBeamer{bottomright}{\def\sjtubeamer@logopos{bottomright}}
+\DeclareOptionBeamer{bottomleft}{\def\sjtubeamer@logopos{bottomleft}}
+%    \end{macrocode}
+%  \end{macro}
+%
 %   $\rightarrow$ Then, the user's option will be processed after this (at the end of this subsection).
 %    \begin{macrocode}
 \ProcessOptionsBeamer
@@ -161,6 +176,7 @@
 \PassOptionsToPackage{\sjtubeamer@lum}{beamercolorthemesjtubeamer}
 \PassOptionsToPackage{\sjtubeamer@lang}{beamerinnerthemesjtubeamer}
 \PassOptionsToPackage{\sjtubeamer@nav}{beamerouterthemesjtubeamer}
+\PassOptionsToPackage{\sjtubeamer@logopos}{beamerouterthemesjtubeamer}
 %    \end{macrocode}
 %
 %   The following code is executed when it is in <presentation> mode.

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/09/04 sjtubeamer parent theme v2.0.0]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/09/17 sjtubeamer parent theme v2.1.0]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/09/22 sjtubeamer parent theme v2.1.0]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/09/25 sjtubeamer parent theme v2.2.0]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/09/17 sjtubeamer parent theme v2.1.0]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/09/22 sjtubeamer parent theme v2.1.0]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -68,7 +68,7 @@
 %    \begin{macrocode}
 %<*maxplus>
 \DeclareOptionBeamer{maxplus}{
-  \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topleft}}
+  \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 %</maxplus>
 %<*max>
 \DeclareOptionBeamer{max}{
@@ -80,7 +80,7 @@
 %</min>
 %<*my>
 \DeclareOptionBeamer{my}{
-  \def\sjtubeamer@cover{my}\def\sjtubeamer@logopos{bottomleft}}
+  \def\sjtubeamer@cover{my}\def\sjtubeamer@logopos{bottomright}}
     % reserved for customization
 %</my>
 %    \end{macrocode}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -157,10 +157,8 @@
 %  \begin{macro}{\sjtubeamer@logopos}
 %   Choose the override outer logo position. No default option will get executed since it has already been executed by the selection of \verb"\sjtubeamer@cover".
 %    \begin{macrocode}
-\DeclareOptionBeamer{topleft}{\def\sjtubeamer@logopos{topleft}}
 \DeclareOptionBeamer{topright}{\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{bottomright}{\def\sjtubeamer@logopos{bottomright}}
-\DeclareOptionBeamer{bottomleft}{\def\sjtubeamer@logopos{bottomleft}}
 %    \end{macrocode}
 %  \end{macro}
 %

--- a/src/source/latexmkrc
+++ b/src/source/latexmkrc
@@ -1,0 +1,2 @@
+$pdflatex = "pdflatex --shell-escape %O %S";
+$xelatex = "xelatex --shell-escape %O %S";

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/09/04 cover library for sjtubeamer v2.0.0]
+\ProvidesPackage{sjtucover}[2021/09/17 cover library for sjtubeamer v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/09/17 cover library for sjtubeamer v2.1.0]
+\ProvidesPackage{sjtucover}[2021/09/22 cover library for sjtubeamer v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/09/22 cover library for sjtubeamer v2.1.0]
+\ProvidesPackage{sjtucover}[2021/09/25 cover library for sjtubeamer v2.2.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -61,7 +61,11 @@
 %  \end{macro}
 %
 % \subsubsection{Load TikZ}
-%   Load TikZ package and its related library: \verb"pattern.meta" provides the interface to define a pattern; \verb"fadings" provides the method to create a fading mask; \verb"decoration.pathmorphing" provides the interface to user-define a decoration.
+%   Load TikZ package and its related library: 
+%   \verb"pattern.meta" provides the interface to define a pattern; 
+%   \verb"fadings" provides the method to create a fading mask; 
+%   \verb"decoration.pathmorphing" provides the interface to user-define a decoration.
+%   \verb"external" provides the way for tikz externalization, which will reduce the number of repetitive rendering with the cached pdf.
 %    \begin{macrocode}
 \RequirePackage{tikz}
 %<*compatible>
@@ -69,6 +73,7 @@
 %</compatible>
 \usetikzlibrary{fadings}
 \usetikzlibrary{decorations.pathmorphing}
+\usetikzlibrary{external}
 %    \end{macrocode}
 %
 % \subsubsection{Color Definition}
@@ -94,6 +99,7 @@
 %    You should define a logo \verb"\definelogo{mylogo}{<hc>}{<vc>}" then use it in the contents like:
 %    \verb"\mylogo[white]", where the optional parameter could be the override color beyond the control of main logo color system or \verb"opacity=..." to identify the opacity you want or any other parameter for a TikZ node.
 %   Remember, the picture should be in the vi/ folder.
+%   The externalization will be disabled when using this system to generate logos, locally.
 %    \begin{macrocode}
 \newcommand{\definelogo}[3]{
     % #1: file from vi/ folder
@@ -113,13 +119,16 @@
     \fi
     \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
       % ##1: override color, or opacity=... (optional)
-      \begin{tikzpicture}
-        \begin{scope}
-          \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
-          \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
-            (-1,-1) rectangle (1,1);
-        \end{scope}
-      \end{tikzpicture}
+      {
+        \tikzset{external/export=false}
+        \begin{tikzpicture}
+          \begin{scope}
+            \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
+            \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
+              (-1,-1) rectangle (1,1);
+          \end{scope}
+        \end{tikzpicture}
+      }
     }
 }
 %    \end{macrocode}
@@ -215,7 +224,7 @@
 }
 %</compatible>
 %    \end{macrocode}
-%   For \TeX Live 2018 and even older, it is \emph{not} compatible to use the patterns.meta library for making user-defined patterns. The function will do noting.
+%   For \TeX Live 2018 and even older, it is \emph{not} compatible to use the patterns.meta library for making user-defined patterns. The function will do nothing.
 %    \begin{macrocode}
 %<*!compatible>
 \providecommand{\stamparray}[3]{}
@@ -250,6 +259,12 @@
 }
 %    \end{macrocode}
 % \end{macro}
+%
+%  Enable the externalization and cache all pdf's to \verb"cache/" folder.
+%  NOTICE: the externalization starts from here to avoid the conflict with the \verb"fadings" library.
+%    \begin{macrocode}
+\tikzexternalize[prefix=cache/]
+%    \end{macrocode}
 %
 % \iffalse
 %</package>

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/09/17 Visual Identity System library for sjtubeamer v2.1.0]
+\ProvidesPackage{sjtuvi}[2021/09/22 Visual Identity System library for sjtubeamer v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -102,34 +102,34 @@
 %   The externalization will be disabled when using this system to generate logos, locally.
 %    \begin{macrocode}
 \newcommand{\definelogo}[3]{
-    % #1: file from vi/ folder
-    % #2: horizontal clip (0~1)
-    % #3: vertical clip (0~1)
-    \pgfmathparse{notgreater(#2,#3)}
-    \ifnum\pgfmathresult=1
-      \begin{tikzfadingfrompicture}[name=#1]
-        \fill[black] (-1,-1) rectangle (1,1);
-        \node {\includegraphics[width=1.5cm]{vi/#1}};
-      \end{tikzfadingfrompicture}
-    \else 
-      \begin{tikzfadingfrompicture}[name=#1]
-        \fill[black] (-1,-1) rectangle (1,1);
-        \node {\includegraphics[height=1.5cm]{vi/#1}};
-      \end{tikzfadingfrompicture}
-    \fi
-    \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
-      % ##1: override color, or opacity=... (optional)
-      {
-        \tikzset{external/export=false}
-        \begin{tikzpicture}
-          \begin{scope}
-            \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
-            \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
-              (-1,-1) rectangle (1,1);
-          \end{scope}
-        \end{tikzpicture}
-      }
+  % #1: file from vi/ folder
+  % #2: horizontal clip (0~1)
+  % #3: vertical clip (0~1)
+  \pgfmathparse{notgreater(#2,#3)}
+  \ifnum\pgfmathresult=1
+    \begin{tikzfadingfrompicture}[name=#1]
+      \fill[black] (-1,-1) rectangle (1,1);
+      \node {\includegraphics[width=1.5cm]{vi/#1}};
+    \end{tikzfadingfrompicture}
+  \else 
+    \begin{tikzfadingfrompicture}[name=#1]
+      \fill[black] (-1,-1) rectangle (1,1);
+      \node {\includegraphics[height=1.5cm]{vi/#1}};
+    \end{tikzfadingfrompicture}
+  \fi
+  \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
+    % ##1: override color, or opacity=... (optional)
+    {
+      \tikzset{external/export=false}
+      \begin{tikzpicture}
+        \begin{scope}
+          \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
+          \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
+            (-1,-1) rectangle (1,1);
+        \end{scope}
+      \end{tikzpicture}
     }
+  }
 }
 %    \end{macrocode}
 % \end{macro}
@@ -260,10 +260,17 @@
 %    \end{macrocode}
 % \end{macro}
 %
-%  Enable the externalization and cache all pdf's to \verb"cache/" folder.
+%   Provides the command for deciding if it is in --shell-escape mode.
+%    \begin{macrocode}
+\RequirePackage{pdftexcmds}
+%    \end{macrocode}
+%  Enable the externalization and cache all pdf's to \verb"cache/" folder, if it is in --shell-escape mode (1).
 %  NOTICE: the externalization starts from here to avoid the conflict with the \verb"fadings" library.
 %    \begin{macrocode}
-\tikzexternalize[prefix=cache/]
+\ifnum\pdf@shellescape=1
+  \tikzexternalize[prefix=cache/]
+\else
+\fi
 %    \end{macrocode}
 %
 % \iffalse

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -265,10 +265,12 @@
 \RequirePackage{pdftexcmds}
 %    \end{macrocode}
 %  Enable the externalization and cache all pdf's to \verb"cache/" folder, if it is in --shell-escape mode (1).
-%  NOTICE: the externalization starts from here to avoid the conflict with the \verb"fadings" library.
+%  NOTICE: the externalization starts from the end of preamble to avoid the conflict with the \verb"fadings" library.
 %    \begin{macrocode}
 \ifnum\pdf@shellescape=1
-  \tikzexternalize[prefix=cache/]
+  \AtEndPreamble{
+    \tikzexternalize[prefix=cache/]
+  }
 \else
 \fi
 %    \end{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -119,16 +119,14 @@
   \fi
   \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
     % ##1: override color, or opacity=... (optional)
-    {
-      \tikzset{external/export=false}
-      \begin{tikzpicture}
-        \begin{scope}
-          \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
-          \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
-            (-1,-1) rectangle (1,1);
-        \end{scope}
-      \end{tikzpicture}
-    }
+    \tikzexternaldisable
+    \begin{tikzpicture}
+      \begin{scope}
+        \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
+        \fill [\sjtubeamer@logocolor, ##1, path fading=#1]
+          (-1,-1) rectangle (1,1);
+      \end{scope}
+    \end{tikzpicture}
   }
 }
 %    \end{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -269,7 +269,6 @@
   \AtEndPreamble{
     \tikzexternalize[prefix=cache/]
   }
-\else
 \fi
 %    \end{macrocode}
 %

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -119,8 +119,7 @@
   \fi
   \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
     % ##1: override color, or opacity=... (optional)
-    \tikzexternaldisable
-    \begin{tikzpicture}
+    \begin{tikzpicture}[external/export=false]
       \begin{scope}
         \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
         \fill [\sjtubeamer@logocolor, ##1, path fading=#1]

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/09/04 Visual Identity System library for sjtubeamer v2.0.0]
+\ProvidesPackage{sjtuvi}[2021/09/17 Visual Identity System library for sjtubeamer v2.1.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/09/22 Visual Identity System library for sjtubeamer v2.1.0]
+\ProvidesPackage{sjtuvi}[2021/09/25 Visual Identity System library for sjtubeamer v2.2.0]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/support/tutorial/step12.tex
+++ b/src/support/tutorial/step12.tex
@@ -1,5 +1,5 @@
 \documentclass{ctexbeamer}
-\usetheme[min,draft]{sjtubeamer}
+\usetheme[min]{sjtubeamer}
 \begin{document}
 \begin{frame}
   \frametitle{图}

--- a/src/support/tutorial/step12.tex
+++ b/src/support/tutorial/step12.tex
@@ -1,5 +1,5 @@
 \documentclass{ctexbeamer}
-\usetheme[min]{sjtubeamer}
+\usetheme[min,draft]{sjtubeamer}
 \begin{document}
 \begin{frame}
   \frametitle{图}


### PR DESCRIPTION
### 徽标位置

由于底部的工具栏重写（为了不与脚注碰撞），导致 logo 需要换一个地方显示。
- 使用 `maxplus` 会连带logo为右上角显示。
- 使用 `max` 会连带logo为右下角显示。
- 使用 `min` 会连带logo为右上角显示。
- 使用 `my` 会连带logo为右下角显示。

也可以分别使用 `bottomright`, `topright` 覆盖显示选项。

###  缓存 tikz 图像（实验性）

如果打开了 `--shell-escape` 编译开关，将会对 tikz 图像进行缓存。对内部一些不必缓存的元素进行了保护。由于处于实验性阶段，默认将会关闭。