### PR TITLE
fix: tikz externalization on Overleaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ SJTUBeamer 是上海交通大学的非官方 Beamer 模版。您可以使用 SJT
 %   shadow     tree       smoothtree
 % *siderbar 推荐与 max 一起使用。
 
+% \tikzexternalize[prefix=cache/]
+% 如果您需要缓存 tikz 图像，请取消注释上一行，并在编译选项中添加 -shell-escape。
+
 \usepackage[backend=biber,style=gb7714-2015]{biblatex}
 \addbibresource{thesis.bib}
 

--- a/README_en.md
+++ b/README_en.md
@@ -29,6 +29,9 @@ Current document `main.tex` is an example documentation of *How to Use LaTeX to 
 %   shadow     tree       smoothtree
 % *siderbar is recommended to be used with max option.
 
+% \tikzexternalize[prefix=cache/]
+% To cache the tikz picture, please uncomment the previous line.
+
 \usepackage{biblatex}
 \addbibresource{thesis.bib}
 

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/10/02 sjtubeamer color theme v2.2.2]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/10/05 sjtubeamer color theme v2.2.3]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/10/02 sjtubeamer font theme v2.2.2]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/10/05 sjtubeamer font theme v2.2.3]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/10/02 sjtubeamer inner theme v2.2.2]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/10/05 sjtubeamer inner theme v2.2.3]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@inner@cover{maxplus}}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/10/02 sjtubeamer outer theme v2.2.2]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/10/05 sjtubeamer outer theme v2.2.3]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/10/02 sjtubeamer parent theme v2.2.2]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/10/05 sjtubeamer parent theme v2.2.3]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/main.tex
+++ b/main.tex
@@ -115,6 +115,9 @@
 %   shadow     tree       smoothtree
 % *siderbar 推荐与 max 一起使用。
 
+% \tikzexternalize[prefix=cache/]
+% 如果您需要缓存 tikz 图像，请取消注释上一行，并在编译选项中添加 -shell-escape。
+
 \author{Alexara Wu}
 \institute[SJTUG]{上海交通大学 Linux 用户组}
 \date{\the\year 年 \the\month 月}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/10/02 cover library for sjtubeamer v2.2.2]
+\ProvidesPackage{sjtucover}[2021/10/05 cover library for sjtubeamer v2.2.3]
 \RequirePackage{sjtuvi}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@sjtucover@cover{maxplus}}
 \DeclareOptionBeamer{max}{\def\sjtubeamer@sjtucover@cover{max}}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/10/02 Visual Identity System library for sjtubeamer v2.2.2]
+\ProvidesPackage{sjtuvi}[2021/10/05 Visual Identity System library for sjtubeamer v2.2.3]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -65,7 +65,8 @@
   \fi
   \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
     % ##1: override color, or opacity=... (optional)
-    \begin{tikzpicture}[external/export=false]
+    \tikzexternaldisable
+    \begin{tikzpicture}
       \begin{scope}
         \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
         \fill [\sjtubeamer@logocolor, ##1, path fading=#1]

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -160,12 +160,6 @@
     \pgfpathlineto{\pgfpointdecoratedpathlast}
   }
 }
-\RequirePackage{pdftexcmds}
-\ifnum\pdf@shellescape=1
-  \AtEndPreamble{
-    \tikzexternalize[prefix=cache/]
-  }
-\fi
 \endinput
 %%
 %% End of file `sjtuvi.sty'.

--- a/src/build.lua
+++ b/src/build.lua
@@ -14,6 +14,7 @@ else
     typesetexe       = "xelatex"
 end
 
+typesetopts      = "-interaction=nonstopmode -shell-escape"
 typesetfiles     = {"sjtubeamerdevguide.tex","sjtubeamer.tex"}
 -- typesetfiles     = {"sjtubeamer.tex"}
 -- typesetruns      = 1 -- for debug. Some reference may not be linked.

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -414,6 +414,7 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[1]{stepcache.tex}
 
 \begin{enumerate}
+  \item \themename\ 已经加载了 \verb"\usetikzlibrary{external}"。
   \item[\faExclamationTriangle] 如果使用的是 Overleaf 这种在线 \LaTeX\ 编译器，您必须要在主文档内使用 \verb"\tikzexternalize[prefix=cache/]" 命令，并且要在同级目录下新建 \verb"cache/" 文件夹，其中应该还有一个占位文档（比如 \verb".gitkeep"）。可参见 \href{https://www.overleaf.com/learn/latex/Questions/I_have_a_lot_of_tikz%2C_matlab2tikz_or_pgfplots_figures%2C_so_I%27m_getting_a_compilation_timeout._Can_I_externalise_my_figures%3F}{相关说明}。
 \end{enumerate}
 

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -405,8 +405,16 @@ fontupper=\sffamily,colupper=white}
 
 \begin{enumerate}\small
   \item 需要加载 \texttt{pgfplots} 宏包，必要时额外加载 \texttt{pgfplotstable} 宏包以读取文件数据。可以使用 \href{https://logcreative.github.io/PGFPlotsEdt/}{PGFPlots 统计绘图编辑器} 生成上述代码。
-  \item[\faExclamationTriangle] 过多的统计图会增长编译时间，不宜过多使用。
-  \item[\faInfoCircle] 现在的版本对于 Ti\emph{k}Z 插图有实验性的优化，当编译采用 \verb"--shell-escape" 开关时，会启动缓存模式。第一次编译时因为需要渲染缓存会稍慢，但是后面的编译都将使用这次编译的产物，就如直接添加图片一样，就会变得快起来。
+\end{enumerate}
+
+\section{缓存}
+
+如果你需要使用较多的 Ti\emph{k}Z 和 \texttt{pgfplots} 插图，可以考虑启用图像缓存，当图像没有被更改时会采用上一次的编译产物。\themename\ 已经保护了一些不必要缓存的元素。
+
+\beamerdemo[1]{stepcache.tex}
+
+\begin{enumerate}
+  \item[\faExclamationTriangle] 如果使用的是 Overleaf 这种在线 \LaTeX\ 编译器，您必须要在主文档内使用 \verb"\tikzexternalize[prefix=cache/]" 命令，并且要在同级目录下新建 \verb"cache/" 文件夹，其中应该还有一个占位文档（比如 \verb".gitkeep"）。可参见 \href{https://www.overleaf.com/learn/latex/Questions/I_have_a_lot_of_tikz%2C_matlab2tikz_or_pgfplots_figures%2C_so_I%27m_getting_a_compilation_timeout._Can_I_externalise_my_figures%3F}{相关说明}。
 \end{enumerate}
 
 % TODO: 以后的开发计划：Smart Diagram

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/10/02 sjtubeamer color theme v2.2.2]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/10/05 sjtubeamer color theme v2.2.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/10/02 sjtubeamer font theme v2.2.2]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/10/05 sjtubeamer font theme v2.2.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/10/02 sjtubeamer inner theme v2.2.2]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/10/05 sjtubeamer inner theme v2.2.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/10/02 sjtubeamer outer theme v2.2.2]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/10/05 sjtubeamer outer theme v2.2.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/10/02 sjtubeamer parent theme v2.2.2]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/10/05 sjtubeamer parent theme v2.2.3]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/10/02 cover library for sjtubeamer v2.2.2]
+\ProvidesPackage{sjtucover}[2021/10/05 cover library for sjtubeamer v2.2.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -258,19 +258,6 @@
 %    \end{macrocode}
 % \end{macro}
 %
-%   Provides the command for deciding if it is in --shell-escape mode.
-%    \begin{macrocode}
-\RequirePackage{pdftexcmds}
-%    \end{macrocode}
-%  Enable the externalization and cache all pdf's to \verb"cache/" folder, if it is in --shell-escape mode (1).
-%  NOTICE: the externalization starts from the end of preamble to avoid the conflict with the \verb"fadings" library.
-%    \begin{macrocode}
-\ifnum\pdf@shellescape=1
-  \AtEndPreamble{
-    \tikzexternalize[prefix=cache/]
-  }
-\fi
-%    \end{macrocode}
 %
 % \iffalse
 %</package>

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -119,7 +119,8 @@
   \fi
   \expandafter\providecommand\csname #1\endcsname[1][\sjtubeamer@logocolor]{
     % ##1: override color, or opacity=... (optional)
-    \begin{tikzpicture}[external/export=false]
+    \tikzexternaldisable
+    \begin{tikzpicture}
       \begin{scope}
         \clip ({-1.0+#2},{-1.0+#3}) rectangle ({1.0-#2},{1.0-#3});
         \fill [\sjtubeamer@logocolor, ##1, path fading=#1]

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/10/02 Visual Identity System library for sjtubeamer v2.2.2]
+\ProvidesPackage{sjtuvi}[2021/10/05 Visual Identity System library for sjtubeamer v2.2.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/support/tutorial/stepcache.tex
+++ b/src/support/tutorial/stepcache.tex
@@ -4,21 +4,21 @@
 \tikzexternalize[prefix=cache/]
 \begin{document}
 \begin{frame}
-\frametitle{缓存插图}
-\begin{tikzpicture}[scale=0.7]
-  \foreach \x in {1,...,7}{
-    \foreach \y in {\x,...,7}{
-      \draw (\x,\y-1)--(\x,\y);
-      \draw (\x+1,\y)--(\x,\y);
-    }
-  }
-  \foreach \x in {1,...,8}{
-    \pgfmathparse{int(\x-1)}
-    \foreach \y in {\pgfmathresult,...,7}{
-      \node[draw,circle,fill=white,scale=0.6]
-        at (\x,\y) {\x,\y};
-    }
-  }
-\end{tikzpicture}
+  \frametitle{缓存插图}
+  \begin{tikzpicture}[scale=0.7]
+    \foreach \x in {1,...,7}{
+        \foreach \y in {\x,...,7}{
+            \draw (\x,\y-1)--(\x,\y);
+            \draw (\x+1,\y)--(\x,\y);
+          }
+      }
+    \foreach \x in {1,...,8}{
+        \pgfmathparse{int(\x-1)}
+        \foreach \y in {\pgfmathresult,...,7}{
+            \node[draw,circle,fill=white,scale=0.6]
+            at (\x,\y) {\x,\y};
+          }
+      }
+  \end{tikzpicture}
 \end{frame}
 \end{document}

--- a/src/support/tutorial/stepcache.tex
+++ b/src/support/tutorial/stepcache.tex
@@ -1,0 +1,24 @@
+\documentclass{ctexbeamer}
+\usetheme{sjtubeamer}
+\usetikzlibrary{math}
+\tikzexternalize[prefix=cache/]
+\begin{document}
+\begin{frame}
+\frametitle{缓存插图}
+\begin{tikzpicture}[scale=0.7]
+  \foreach \x in {1,...,7}{
+    \foreach \y in {\x,...,7}{
+      \draw (\x,\y-1)--(\x,\y);
+      \draw (\x+1,\y)--(\x,\y);
+    }
+  }
+  \foreach \x in {1,...,8}{
+    \pgfmathparse{int(\x-1)}
+    \foreach \y in {\pgfmathresult,...,7}{
+      \node[draw,circle,fill=white,scale=0.6]
+        at (\x,\y) {\x,\y};
+    }
+  }
+\end{tikzpicture}
+\end{frame}
+\end{document}


### PR DESCRIPTION
最新的版本在 Overleaf 上会被默认开启缓存，现在改为需要用户手动在主文档开启缓存，并且在根目录预留了 cache 文件夹与其内的 dummy file，这样才能让在线编译器正常运转缓存，详见 [相关说明](https://www.overleaf.com/learn/latex/Questions/I_have_a_lot_of_tikz%2C_matlab2tikz_or_pgfplots_figures%2C_so_I%27m_getting_a_compilation_timeout._Can_I_externalise_my_figures%3F)，应当被认为是一些内部机制导致的。

[SJTU LaTeX 文档助手](https://latex.sjtu.edu.cn/)采用的是 2.0.0 稳定版，不会有相关问题，详见 [工程链接](https://latex.sjtu.edu.cn/read/qtjvvcdktrns)（点开后回到主界面，在项目列表里打开模板，在右上角“更多的”里选择“制作一份拷贝”即可开始编辑）。