### PR TITLE
feat: VS Code snippets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@ sjtuvi.sty linguist-generated=true
 beamerfontthemesjtubeamer.sty linguist-generated=true
 beamerouterthemesjtubeamer.sty linguist-generated=true
 sjtucover.sty linguist-generated=true
+sjtubeamer.code-snippets linguist-generated=true
 
 # regression test target file
 *.tlg linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -218,9 +218,6 @@ TSWLatexianTemp*
 # KBibTeX
 *~[0-9]*
 
-# VSCode
-.vscode/*
-
 # auto folder when using emacs and auctex
 ./auto/*
 *.el

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -1,8 +1,44 @@
 {
+	"sjtubeamer@color@color": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@color@color",
+		"body": "\\sjtubeamer@color@color",
+		"description": ""
+	},
+	"sjtubeamer@color@lum": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@color@lum",
+		"body": "\\sjtubeamer@color@lum",
+		"description": ""
+	},
+	"sjtubeamer@inner@cover": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@inner@cover",
+		"body": "\\sjtubeamer@inner@cover",
+		"description": ""
+	},
+	"sjtubeamer@inner@lang": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@inner@lang",
+		"body": "\\sjtubeamer@inner@lang",
+		"description": ""
+	},
+	"sjtubeamer@inner@color": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@inner@color",
+		"body": "\\sjtubeamer@inner@color",
+		"description": ""
+	},
+	"sjtubeamer@logocolor": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@logocolor",
+		"body": "\\sjtubeamer@logocolor",
+		"description": "Change the color variable that controls the logo color to current main color of this theme. Since this template doesn't design a dark background for the contents (it is really not easy to handle with the contents for a dark background).\n"
+	},
 	"logo": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\logo",
-		"body": "\\logo",
+		"body": "\\logo{$1}",
 		"description": "Define logo.\n"
 	},
 	"bgcenterbox": {
@@ -14,7 +50,7 @@
 	"titlegraphic": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\titlegraphic",
-		"body": "\\titlegraphic",
+		"body": "\\titlegraphic{$1}",
 		"description": " Define the title grahic image.\n\n NOTICE: if you are using your own title graphic, please use png image with predefined color and transparency. Since it is beyond the control of logo color system. Or you could use the provided command in the sjtuvi library to create your own masked picture in order to follow the logo color system (The provided picture should be white and transparent in the background).\n\nmax theme has the background.\n"
 	},
 	"coverpage": {
@@ -56,31 +92,31 @@
 	"partpage": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\partpage",
-		"body": "\\partpage",
+		"body": "\\partpage{$1}",
 		"description": "Define the part page beamer template.\n"
 	},
 	"part": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\part",
-		"body": "\\part",
+		"body": "\\part{$1}",
 		"description": "Redirect the part command to make a part page.\nRedefinition on \\beamer@writeslideentrty locally will remove the corresponding navigation dot like what it has been done in the bottom page.\n"
 	},
 	"sectionpage": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\sectionpage",
-		"body": "\\sectionpage",
+		"body": "\\sectionpage{$1}",
 		"description": "Define the section page beamer template.\n"
 	},
 	"subsectionpage": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\subsectionpage",
-		"body": "\\subsectionpage",
+		"body": "\\subsectionpage{$1}",
 		"description": "Define the subection page beamer template.\n"
 	},
 	"highlight": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\highlight",
-		"body": "\\highlight[${1:cprimary}]",
+		"body": "\\highlight[${1:cprimary}]{$2}",
 		"description": "Highlight the given text. Create a primary color background block with white as foreground.\n"
 	},
 	"paragraph": {
@@ -100,6 +136,54 @@
 		"prefix": "codeblock",
 		"body": "\n\\begin{codeblock}[${1:}]{$2}\n\t$3\n\\end{codeblock}\n",
 		"description": "Code block environment is made for presenting code in an obvious way. Two parameters are required. The first parameter is passed to listing, which mostly sets the language to highlight, see the listings package for more details. And the second parameter receives the title to make.\n"
+	},
+	"sjtubeamer@outer@nav": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@outer@nav",
+		"body": "\\sjtubeamer@outer@nav",
+		"description": ""
+	},
+	"sjtubeamer@outer@logopos": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@outer@logopos",
+		"body": "\\sjtubeamer@outer@logopos",
+		"description": ""
+	},
+	"sjtubeamer@cover": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@cover",
+		"body": "\\sjtubeamer@cover",
+		"description": "This macro selects the cover theme.\n\\begin{description}\n\\item[maxplus] The titlegraphic will be a photo.\n\\item[max] The background will be the photo.\n\\item[min] The design will be minimalistic.\n\\item[my]Reserved interface for developers for customized title page and bottom page.\n\\end{description}\n\n$\\rightarrow$ The following will demostrates how to pass options between files.\n\n$\\rightarrow$ To set up an option, use \\DeclareOptionBeamer to let beamer theme receive such an option and store the value into a variable.\n\n$\\rightarrow$ To make the variable easy to follow and avoid duplicates, the naming system is as follows:\n\\begin{itemize}\n\\item Start with the project name sjtubeamer.\n\\item Split by @ symbol and move to the next level.\n\\item The final level should be the variable name itself.\n\\end{itemize}\n"
+	},
+	"sjtubeamer@color": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@color",
+		"body": "\\sjtubeamer@color",
+		"description": "Choose the main color palette.\n\\begin{description}\n\\item[red] The red color palatte. sjtuRed*\n\\item[blue] The blue color palatte. sjtuBlue*\n\\end{description}\n\n"
+	},
+	"sjtubeamer@lum": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@lum",
+		"body": "\\sjtubeamer@lum",
+		"description": "Decide whether it is in light mode or dark mode. Switch the lumination.\n"
+	},
+	"sjtubeamer@lang": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@lang",
+		"body": "\\sjtubeamer@lang",
+		"description": "Set the main language of this beamer. If the user is using ctexbeamer class, the default option will be Chinese. If the user use ctex package after using this theme, such an advanced user should specify the language to Chinese manually.\n\nTODO: may be a built in support for Chinese will be used in the future. Just taken \\RequirePackage[scheme=plain]{ctex} for basic Chinese character support.\n"
+	},
+	"sjtubeamer@nav": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@nav",
+		"body": "\\sjtubeamer@nav",
+		"description": "Choose the outer theme for this template.\n"
+	},
+	"sjtubeamer@logopos": {
+		"scope": "doctex,tex",
+		"prefix": "\\sjtubeamer@logopos",
+		"body": "\\sjtubeamer@logopos",
+		"description": "Choose the override outer logo position. No default option will get executed since it has already been executed by the selection of \\sjtubeamer@cover.\n"
 	},
 	"DefineOption": {
 		"scope": "doctex,tex",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -1,114 +1,114 @@
 {
 	"logo": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\logo",
 		"body": "\\logo",
 		"description": "Define logo.\n"
 	},
 	"bgcenterbox": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\bgcenterbox",
 		"body": "\\bgcenterbox{$1}",
 		"description": "Define a command for USERS to make a centered background box easily. Move the defination on \\sjtubeamer@logocolor to the inner environment, to avoid the shift on centering. And since the definition has already been moved into the inner group, the definition here is \\emph{locale} and no more stack saving is needed.\n"
 	},
 	"titlegraphic": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\titlegraphic",
 		"body": "\\titlegraphic",
 		"description": " Define the title grahic image.\n\n NOTICE: if you are using your own title graphic, please use png image with predefined color and transparency. Since it is beyond the control of logo color system. Or you could use the provided command in the sjtuvi library to create your own masked picture in order to follow the logo color system (The provided picture should be white and transparent in the background).\n\nmax theme has the background.\n"
 	},
 	"coverpage": {
-		"scope": "latex",
+		"scope": "doctex,tex",
 		"prefix": "\\coverpage",
 		"body": "\\coverpage{$1}",
-		"description": "[INTERNAL] Common command for \\titlepage and \\bottompage. Disable externalization for generating title page and bottom page, locally.\nSince the definition on \\sjtubeamer@logocolor is defined in a group, the stack is not necessary to store the value.\n"
+		"description": "Common command for \\titlepage and \\bottompage. Disable externalization for generating title page and bottom page, locally.\nSince the definition on \\sjtubeamer@logocolor is defined in a group, the stack is not necessary to store the value.\n"
 	},
 	"titlepage": {
-		"scope": "latex",
+		"scope": "doctex,tex",
 		"prefix": "\\titlepage",
 		"body": "\\titlepage",
-		"description": "[INTERNAL] Call the title page template to make a title page. This is a patch for the original \\titlepage command, to fit with the logo color system.\n"
+		"description": "Call the title page template to make a title page. This is a patch for the original \\titlepage command, to fit with the logo color system.\n"
 	},
 	"maketitle": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\maketitle",
 		"body": "\\maketitle[${1:\\sjtubeamer@inner@cover}]",
 		"description": "Patch make title command. It will receive an optional argument for switching different type of title page. The set on beamer template is inside a group, so the setting is locale.\n"
 	},
 	"bottompage": {
-		"scope": "latex",
+		"scope": "doctex,tex",
 		"prefix": "\\bottompage",
 		"body": "\\bottompage",
-		"description": "[INTERNAL] Call the bottom page template to make a bottom page.\n"
+		"description": "Call the bottom page template to make a bottom page.\n"
 	},
 	"bottomthanks": {
-		"scope": "latex",
+		"scope": "doctex,tex",
 		"prefix": "\\bottomthanks",
 		"body": "\\bottomthanks",
-		"description": "[INTERNAL] The \"Thank You\" caption in the bottom page.\n"
+		"description": "The \"Thank You\" caption in the bottom page.\n"
 	},
 	"makebottom": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\makebottom",
 		"body": "\\makebottom[${1:\\sjtubeamer@inner@cover}]",
 		"description": "Make the bottom page. Not a built-in command.\nRedefinition on \\beamer@writeslideentrty locally will remove the corresponding navigation dot for miniframe outer theme. This is not necessary for title page, since it should not belong to any sections.\n"
 	},
 	"partpage": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\partpage",
 		"body": "\\partpage",
 		"description": "Define the part page beamer template.\n"
 	},
 	"part": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\part",
 		"body": "\\part",
 		"description": "Redirect the part command to make a part page.\nRedefinition on \\beamer@writeslideentrty locally will remove the corresponding navigation dot like what it has been done in the bottom page.\n"
 	},
 	"sectionpage": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\sectionpage",
 		"body": "\\sectionpage",
 		"description": "Define the section page beamer template.\n"
 	},
 	"subsectionpage": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\subsectionpage",
 		"body": "\\subsectionpage",
 		"description": "Define the subection page beamer template.\n"
 	},
 	"highlight": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\highlight",
 		"body": "\\highlight[${1:cprimary}]",
 		"description": "Highlight the given text. Create a primary color background block with white as foreground.\n"
 	},
 	"paragraph": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\paragraph",
 		"body": "\\paragraph{$1}",
 		"description": "Use \\highlight macro for making contrast.\nSince beamer has deleted \\paragraph macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from article class.\n"
 	},
 	"DefineOption": {
-		"scope": "latex",
+		"scope": "doctex,tex",
 		"prefix": "\\DefineOption",
 		"body": "\\DefineOption{$1}{$2}{$3}",
-		"description": "[INTERNAL] Define the beamer option on the corresponding package, key and value.\n"
+		"description": "Define the beamer option on the corresponding package, key and value.\n"
 	},
 	"EqualOption": {
-		"scope": "latex",
+		"scope": "doctex,tex",
 		"prefix": "\\EqualOption",
 		"body": "\\EqualOption",
-		"description": "[INTERNAL] To check if the option on package, key is equal to value.\n\nHere, a dummy trick is used to pass the if condition.\nSince LaTeX handles \\if differently.\n\\iftrue will eliminate the nearest \\else and \\fi but remains other extra \\fi and throws errors.\nTo avoid this, if the macro is expanded after \\if, T=T, the condition holds and finish the current pair. And continues to process the real defined macro. This solution is somehow to combat against the \\LaTeX compiler. In modern \\LaTeX 3, it is not so nasty to deal with neseted conditions. \n\\iffalse doesn't need to be considered.\n"
+		"description": "To check if the option on package, key is equal to value.\n\nHere, a dummy trick is used to pass the if condition.\nSince LaTeX handles \\if differently.\n\\iftrue will eliminate the nearest \\else and \\fi but remains other extra \\fi and throws errors.\nTo avoid this, if the macro is expanded after \\if, T=T, the condition holds and finish the current pair. And continues to process the real defined macro. This solution is somehow to combat against the \\LaTeX compiler. In modern \\LaTeX 3, it is not so nasty to deal with neseted conditions. \n\\iffalse doesn't need to be considered.\n"
 	},
 	"definelogo": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\definelogo",
 		"body": "\\definelogo{$1}{$2}{$3}",
 		"description": "Define a mask picture to make its different color variants.\nThe first argument assigns the file name and the second sets the horizontal cropping and the third sets the vertical cropping. Notice that the cropping is symmetrical (double the length). When the horizontal cropping is greater than the vertical cropping, the mask will be placed by its height, otherwise by its width. The domain for both cropping parameters is 0 to 1.\nYou should define a logo \\definelogo{mylogo}{<hc>}{<vc>} then use it in the contents like:\n\\mylogo[white], where the optional parameter could be the override color beyond the control of main logo color system or opacity=... to identify the opacity you want or any other parameter for a TikZ node.\nRemember, the picture should be in the vi/ folder.\nThe externalization will be disabled when using this system to generate logos, locally.\n"
 	},
 	"stamparray": {
-		"scope": "latex",
+		"scope": "doctex,tex,latex",
 		"prefix": "\\stamparray",
 		"body": "\\stamparray{$1}{$2}{$3}",
 		"description": "Create the stamp array in the TikZ environment.\n\nNotice \\TeX{} is not good at handling parameters. Always remember to store it into a temporary variable. Register \\pgfmathresult will store the result of \\pgfmathparse.\n"

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -89,6 +89,18 @@
 		"body": "\\paragraph{$1}",
 		"description": "Use \\highlight macro for making contrast.\nSince beamer has deleted \\paragraph macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from article class.\n"
 	},
+	"stampbox": {
+		"scope": "doctex,tex,latex",
+		"prefix": "stampbox",
+		"body": "\n\\begin{stampbox}[${1:cprimary}]\n\t$2\n\\end{stampbox}\n",
+		"description": "Make a stampbox border, which is a decoration advice from SJTU VI. It has the dependency on stampline from sjtuvi package.\n"
+	},
+	"codeblock": {
+		"scope": "doctex,tex,latex",
+		"prefix": "codeblock",
+		"body": "\n\\begin{codeblock}[${1:}]{$2}\n\t$3\n\\end{codeblock}\n",
+		"description": "Code block environment is made for presenting code in an obvious way. Two parameters are required. The first parameter is passed to listing, which mostly sets the language to highlight, see the listings package for more details. And the second parameter receives the title to make.\n"
+	},
 	"DefineOption": {
 		"scope": "doctex,tex",
 		"prefix": "\\DefineOption",
@@ -107,10 +119,22 @@
 		"body": "\\definelogo{$1}{$2}{$3}",
 		"description": "Define a mask picture to make its different color variants.\nThe first argument assigns the file name and the second sets the horizontal cropping and the third sets the vertical cropping. Notice that the cropping is symmetrical (double the length). When the horizontal cropping is greater than the vertical cropping, the mask will be placed by its height, otherwise by its width. The domain for both cropping parameters is 0 to 1.\nYou should define a logo \\definelogo{mylogo}{<hc>}{<vc>} then use it in the contents like:\n\\mylogo[white], where the optional parameter could be the override color beyond the control of main logo color system or opacity=... to identify the opacity you want or any other parameter for a TikZ node.\nRemember, the picture should be in the vi/ folder.\nThe externalization will be disabled when using this system to generate logos, locally.\n"
 	},
+	"stamp": {
+		"scope": "doctex,tex,latex",
+		"prefix": "stamp",
+		"body": "stamp",
+		"description": "Declare stamp pattern to make a stamp array.\n\nThe newest version of TikZ provides the interface to user-define a pattern. Obeying compatibility philosophy, use \\pgfkeyvalueof interface to get parameters in a standard way. The unit is first tested in a standalone file and previewed by TikZEdt.\n"
+	},
 	"stamparray": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\stamparray",
 		"body": "\\stamparray{$1}{$2}{$3}",
 		"description": "Create the stamp array in the TikZ environment.\n\nNotice \\TeX{} is not good at handling parameters. Always remember to store it into a temporary variable. Register \\pgfmathresult will store the result of \\pgfmathparse.\n"
+	},
+	"stampline": {
+		"scope": "doctex,tex,latex",
+		"prefix": "stampline",
+		"body": "stampline",
+		"description": "Declare a decoration to make a loop stampline.\n\nNotice that auto corner on length is open to avoid spikes where the state hasn't meet final yet.\n"
 	},
 }

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -1,0 +1,116 @@
+{
+	"logo": {
+		"scope": "latex",
+		"prefix": "\\logo",
+		"body": "\\logo",
+		"description": "Define logo.\n"
+	},
+	"bgcenterbox": {
+		"scope": "latex",
+		"prefix": "\\bgcenterbox",
+		"body": "\\bgcenterbox{$1}",
+		"description": "Define a command for USERS to make a centered background box easily. Move the defination on \\sjtubeamer@logocolor to the inner environment, to avoid the shift on centering. And since the definition has already been moved into the inner group, the definition here is \\emph{locale} and no more stack saving is needed.\n"
+	},
+	"titlegraphic": {
+		"scope": "latex",
+		"prefix": "\\titlegraphic",
+		"body": "\\titlegraphic",
+		"description": " Define the title grahic image.\n\n NOTICE: if you are using your own title graphic, please use png image with predefined color and transparency. Since it is beyond the control of logo color system. Or you could use the provided command in the sjtuvi library to create your own masked picture in order to follow the logo color system (The provided picture should be white and transparent in the background).\n\nmax theme has the background.\n"
+	},
+	"coverpage": {
+		"scope": "latex",
+		"prefix": "\\coverpage",
+		"body": "\\coverpage{$1}",
+		"description": "Common command for \\titlepage and \\bottompage. Disable externalization for generating title page and bottom page, locally.\nSince the definition on \\sjtubeamer@logocolor is defined in a group, the stack is not necessary to store the value.\n"
+	},
+	"titlepage": {
+		"scope": "latex",
+		"prefix": "\\titlepage",
+		"body": "\\titlepage",
+		"description": "Call the title page template to make a title page. This is a patch for the original \\titlepage command, to fit with the logo color system.\n"
+	},
+	"maketitle": {
+		"scope": "latex",
+		"prefix": "\\maketitle",
+		"body": "\\maketitle[${1:\\sjtubeamer@inner@cover}]",
+		"description": "Patch make title command. It will receive an optional argument for switching different type of title page. The set on beamer template is inside a group, so the setting is locale.\n"
+	},
+	"bottompage": {
+		"scope": "latex",
+		"prefix": "\\bottompage",
+		"body": "\\bottompage",
+		"description": "Call the bottom page template to make a bottom page.\n"
+	},
+	"bottomthanks": {
+		"scope": "latex",
+		"prefix": "\\bottomthanks",
+		"body": "\\bottomthanks",
+		"description": "The \"Thank You\" caption in the bottom page.\n"
+	},
+	"makebottom": {
+		"scope": "latex",
+		"prefix": "\\makebottom",
+		"body": "\\makebottom[${1:\\sjtubeamer@inner@cover}]",
+		"description": "Make the bottom page. Not a built-in command.\nRedefinition on \\beamer@writeslideentrty locally will remove the corresponding navigation dot for miniframe outer theme. This is not necessary for title page, since it should not belong to any sections.\n"
+	},
+	"partpage": {
+		"scope": "latex",
+		"prefix": "\\partpage",
+		"body": "\\partpage",
+		"description": "Define the part page beamer template.\n"
+	},
+	"part": {
+		"scope": "latex",
+		"prefix": "\\part",
+		"body": "\\part",
+		"description": "Redirect the part command to make a part page.\nRedefinition on \\beamer@writeslideentrty locally will remove the corresponding navigation dot like what it has been done in the bottom page.\n"
+	},
+	"sectionpage": {
+		"scope": "latex",
+		"prefix": "\\sectionpage",
+		"body": "\\sectionpage",
+		"description": "Define the section page beamer template.\n"
+	},
+	"subsectionpage": {
+		"scope": "latex",
+		"prefix": "\\subsectionpage",
+		"body": "\\subsectionpage",
+		"description": "Define the subection page beamer template.\n"
+	},
+	"highlight": {
+		"scope": "latex",
+		"prefix": "\\highlight",
+		"body": "\\highlight",
+		"description": "Highlight the given text. Create a primary color background block with white as foreground.\n"
+	},
+	"paragraph": {
+		"scope": "latex",
+		"prefix": "\\paragraph",
+		"body": "\\paragraph{$1}",
+		"description": "Use \\highlight macro for making contrast.\nSince beamer has deleted \\paragraph macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from article class.\n"
+	},
+	"DefineOption": {
+		"scope": "latex",
+		"prefix": "\\DefineOption",
+		"body": "\\DefineOption{$1}{$2}{$3}",
+		"description": "Define the beamer option on the corresponding package, key and value.\n"
+	},
+	"EqualOption": {
+		"scope": "latex",
+		"prefix": "\\EqualOption",
+		"body": "\\EqualOption",
+		"description": "To check if the option on package, key is equal to value.\n\nHere, a dummy trick is used to pass the if condition.\nSince LaTeX handles \\if differently.\n\\iftrue will eliminate the nearest \\else and \\fi but remains other extra \\fi and throws errors.\nTo avoid this, if the macro is expanded after \\if, T=T, the condition holds and finish the current pair. And continues to process the real defined macro. This solution is somehow to combat against the \\LaTeX compiler. In modern \\LaTeX 3, it is not so nasty to deal with neseted conditions. \n\\iffalse doesn't need to be considered.\n"
+	},
+	"definelogo": {
+		"scope": "latex",
+		"prefix": "\\definelogo",
+		"body": "\\definelogo{$1}{$2}{$3}",
+		"description": "Define a mask picture to make its different color variants.\nThe first argument assigns the file name and the second sets the horizontal cropping and the third sets the vertical cropping. Notice that the cropping is symmetrical (double the length). When the horizontal cropping is greater than the vertical cropping, the mask will be placed by its height, otherwise by its width. The domain for both cropping parameters is 0 to 1.\nYou should define a logo \\definelogo{mylogo}{<hc>}{<vc>} then use it in the contents like:\n\\mylogo[white], where the optional parameter could be the override color beyond the control of main logo color system or opacity=... to identify the opacity you want or any other parameter for a TikZ node.\nRemember, the picture should be in the vi/ folder.\nThe externalization will be disabled when using this system to generate logos, locally.\n"
+	},
+	"stamparray": {
+		"scope": "latex",
+		"prefix": "\\stamparray",
+		"body": "\\stamparray{$1}{$2}{$3}",
+		"description": "Create the stamp array in the TikZ environment.\n\nNotice \\TeX{} is not good at handling parameters. Always remember to store it into a temporary variable. Register \\pgfmathresult will store the result of \\pgfmathparse.\n"
+	},
+}

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -80,7 +80,7 @@
 	"highlight": {
 		"scope": "latex",
 		"prefix": "\\highlight",
-		"body": "\\highlight",
+		"body": "\\highlight[${1:cprimary}]",
 		"description": "Highlight the given text. Create a primary color background block with white as foreground.\n"
 	},
 	"paragraph": {

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -21,13 +21,13 @@
 		"scope": "latex",
 		"prefix": "\\coverpage",
 		"body": "\\coverpage{$1}",
-		"description": "Common command for \\titlepage and \\bottompage. Disable externalization for generating title page and bottom page, locally.\nSince the definition on \\sjtubeamer@logocolor is defined in a group, the stack is not necessary to store the value.\n"
+		"description": "[INTERNAL] Common command for \\titlepage and \\bottompage. Disable externalization for generating title page and bottom page, locally.\nSince the definition on \\sjtubeamer@logocolor is defined in a group, the stack is not necessary to store the value.\n"
 	},
 	"titlepage": {
 		"scope": "latex",
 		"prefix": "\\titlepage",
 		"body": "\\titlepage",
-		"description": "Call the title page template to make a title page. This is a patch for the original \\titlepage command, to fit with the logo color system.\n"
+		"description": "[INTERNAL] Call the title page template to make a title page. This is a patch for the original \\titlepage command, to fit with the logo color system.\n"
 	},
 	"maketitle": {
 		"scope": "latex",
@@ -39,13 +39,13 @@
 		"scope": "latex",
 		"prefix": "\\bottompage",
 		"body": "\\bottompage",
-		"description": "Call the bottom page template to make a bottom page.\n"
+		"description": "[INTERNAL] Call the bottom page template to make a bottom page.\n"
 	},
 	"bottomthanks": {
 		"scope": "latex",
 		"prefix": "\\bottomthanks",
 		"body": "\\bottomthanks",
-		"description": "The \"Thank You\" caption in the bottom page.\n"
+		"description": "[INTERNAL] The \"Thank You\" caption in the bottom page.\n"
 	},
 	"makebottom": {
 		"scope": "latex",
@@ -93,13 +93,13 @@
 		"scope": "latex",
 		"prefix": "\\DefineOption",
 		"body": "\\DefineOption{$1}{$2}{$3}",
-		"description": "Define the beamer option on the corresponding package, key and value.\n"
+		"description": "[INTERNAL] Define the beamer option on the corresponding package, key and value.\n"
 	},
 	"EqualOption": {
 		"scope": "latex",
 		"prefix": "\\EqualOption",
 		"body": "\\EqualOption",
-		"description": "To check if the option on package, key is equal to value.\n\nHere, a dummy trick is used to pass the if condition.\nSince LaTeX handles \\if differently.\n\\iftrue will eliminate the nearest \\else and \\fi but remains other extra \\fi and throws errors.\nTo avoid this, if the macro is expanded after \\if, T=T, the condition holds and finish the current pair. And continues to process the real defined macro. This solution is somehow to combat against the \\LaTeX compiler. In modern \\LaTeX 3, it is not so nasty to deal with neseted conditions. \n\\iffalse doesn't need to be considered.\n"
+		"description": "[INTERNAL] To check if the option on package, key is equal to value.\n\nHere, a dummy trick is used to pass the if condition.\nSince LaTeX handles \\if differently.\n\\iftrue will eliminate the nearest \\else and \\fi but remains other extra \\fi and throws errors.\nTo avoid this, if the macro is expanded after \\if, T=T, the condition holds and finish the current pair. And continues to process the real defined macro. This solution is somehow to combat against the \\LaTeX compiler. In modern \\LaTeX 3, it is not so nasty to deal with neseted conditions. \n\\iffalse doesn't need to be considered.\n"
 	},
 	"definelogo": {
 		"scope": "latex",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/11/22 sjtubeamer color theme v2.3.1]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/11/22 sjtubeamer color theme v2.3.2]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/10/29 sjtubeamer color theme v2.3.0]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/11/22 sjtubeamer color theme v2.3.1]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/10/29 sjtubeamer font theme v2.3.0]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/11/22 sjtubeamer font theme v2.3.1]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/11/22 sjtubeamer font theme v2.3.1]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/11/22 sjtubeamer font theme v2.3.2]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -232,7 +232,9 @@
   top=2pt,
   bottom=2pt
 }
-\def\paragraph#1{\highlight{#1}~}
+\providecommand{\paragraph}[1]{
+  \highlight{#1}~
+}
 \newtcolorbox{stampbox}[1][cprimary]{%
   capture=hbox,
   enhanced,

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/10/29 sjtubeamer inner theme v2.3.0]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/11/22 sjtubeamer inner theme v2.3.1]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@inner@cover{maxplus}}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/11/22 sjtubeamer inner theme v2.3.1]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/11/22 sjtubeamer inner theme v2.3.2]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@inner@cover{maxplus}}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/10/29 sjtubeamer outer theme v2.3.0]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/11/22 sjtubeamer outer theme v2.3.1]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/11/22 sjtubeamer outer theme v2.3.1]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/11/22 sjtubeamer outer theme v2.3.2]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/11/22 sjtubeamer parent theme v2.3.1]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/11/22 sjtubeamer parent theme v2.3.2]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/10/29 sjtubeamer parent theme v2.3.0]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/11/22 sjtubeamer parent theme v2.3.1]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/10/29 cover library for sjtubeamer v2.3.0]
+\ProvidesPackage{sjtucover}[2021/11/22 cover library for sjtubeamer v2.3.1]
 \RequirePackage{sjtuvi}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@sjtucover@cover{maxplus}}
 \DeclareOptionBeamer{max}{\def\sjtubeamer@sjtucover@cover{max}}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/11/22 cover library for sjtubeamer v2.3.1]
+\ProvidesPackage{sjtucover}[2021/11/22 cover library for sjtubeamer v2.3.2]
 \RequirePackage{sjtuvi}
 \DeclareOptionBeamer{maxplus}{\def\sjtubeamer@sjtucover@cover{maxplus}}
 \DeclareOptionBeamer{max}{\def\sjtubeamer@sjtucover@cover{max}}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/10/29 Visual Identity System library for sjtubeamer v2.3.0]
+\ProvidesPackage{sjtuvi}[2021/11/22 Visual Identity System library for sjtubeamer v2.3.1]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/11/22 Visual Identity System library for sjtubeamer v2.3.1]
+\ProvidesPackage{sjtuvi}[2021/11/22 Visual Identity System library for sjtubeamer v2.3.2]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/build.lua
+++ b/src/build.lua
@@ -95,7 +95,6 @@ end
 
 snippetdir = "../.vscode"
 snippetfilename = "sjtubeamer.code-snippets"
-scope = 'latex'
 
 -- Generate Visual Studio Code snippets
 -- To make it run properly, please follow the Coding Style guideline.
@@ -150,21 +149,22 @@ function gen_snippets()
             local env_beg = string.match(line, "\\begin{macro}{(\\%a+)}")
             if env_beg ~= nil then
                 in_macro = env_beg
-                local match_comm = string.gsub(env_beg, "\\", "\\\\")
-                snippetfile:write("\t\"" .. string.gsub(env_beg,"\\","") .. "\": {\n")
-                snippetfile:write("\t\t\"scope\": \"" .. scope .. "\",\n")
-                snippetfile:write("\t\t\"prefix\": \"" .. match_comm .. "\",\n")
-                snippetfile:write("\t\t\"body\": \"")
             end
             -- Find end macro DocTeX environment, see Coding Style 2.3.1
             if string.match(line, "\\end{macro}") ~= nil and in_macro ~= nil then
                 -- This macro is processed complete.
+                local match_comm = string.gsub(in_macro, "\\", "\\\\")
+                local scope = "doctex,tex"
+                if captured == 2 or macro_body == "" then
+                    scope = scope .. ",latex"   -- public use
+                end
                 if macro_body == "" then
-                    macro_body = string.gsub(in_macro, "\\", "\\\\")
+                    macro_body = match_comm     -- no abvious definition
                 end
-                if captured == 1 then
-                    macro_desc = "[INTERNAL] " .. macro_desc
-                end
+                snippetfile:write("\t\"" .. string.gsub(in_macro,"\\","") .. "\": {\n")
+                snippetfile:write("\t\t\"scope\": \"" .. scope .. "\",\n")
+                snippetfile:write("\t\t\"prefix\": \"" .. match_comm .. "\",\n")
+                snippetfile:write("\t\t\"body\": \"")
                 snippetfile:write(macro_body .. "\",\n")
                 snippetfile:write("\t\t\"description\": \"" .. macro_desc .. "\"\n")
                 snippetfile:write("\t},\n")

--- a/src/build.lua
+++ b/src/build.lua
@@ -105,7 +105,9 @@ function gen_snippets()
     end
     snippetfile = io.open(snippetdir .. "/" .. snippetfilename, "w")
     snippetfile:write("{\n")
-    for _, p in ipairs(filelist(sourcefiledir, "*.dtx")) do
+    dtx_filelist = filelist(sourcefiledir, "*.dtx")
+    table.sort(dtx_filelist)        -- sort to avoid difference
+    for _, p in ipairs(dtx_filelist) do
         local in_macro = nil
         local macro_body = ""
         local macro_desc = ""

--- a/src/build.lua
+++ b/src/build.lua
@@ -117,7 +117,7 @@ function gen_snippets()
                 -- Find TeX style definition, see Coding Style 2.1.2
                 local def_param = string.match(line, "\\def" .. in_macro .. "([#%d]+)")
                 -- Find LaTeX style definition, see Coding Style 2.1.3
-                local comm_param, param_default = string.match(line, "\\[renew|provide|new]*command{" .. in_macro .. "}%[(%d)%]([%[%a*@*\\*%]]*)")
+                local comm_param, param_default = string.match(line, "\\[renew|provide|new]*%a+{" .. in_macro .. "}%[(%d)%]([%[%a*@*\\*%]]*)")
                 if def_param ~= nil then
                     def_param = string.gsub(def_param, "#(%d)", "{$%1}")
                     macro_body = macro_body .. "\\" .. in_macro .. def_param

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -154,9 +154,7 @@ fontupper=\sffamily,colupper=white}
 
 \begin{enumerate}
   \item git 用户可以使用
-        \begin{quotation}\ttfamily
-          git clone https://mirror.sjtu.edu.cn/git/SJTUBeamer.git/
-        \end{quotation}
+        \begin{verbatim}git clone https://mirror.sjtu.edu.cn/git/SJTUBeamer.git/\end{verbatim}
         克隆本存储库。
   \item 或者前往 GitHub 上的 \faGithub{}~\href{https://github.com/sjtug/SJTUBeamer}{sjtug/SJTUBeamer} 页面，点击 \xbutton[green]{Code} 按钮下载压缩文件，在解压后的主目录里新建 \TeX{} 源文件即可调用该模板。
   \item 或者点击进入存储库侧栏的 \href{https://github.com/sjtug/SJTUBeamer/releases}{\textsf{Releases}} 下载查看最新发布版本，并下载 \textsf{Assets} 栏的 \texttt{sjtubeamer-ctan.zip}。
@@ -484,7 +482,7 @@ fontupper=\sffamily,colupper=white}
 
 \section{迁移到其他主题}
 
-上文中所有 \themename\ 独占的功能都已经用星号 $^*$ 标记。在迁移到其他的主题时，您需要手动重定向这些独占命令。
+上文中所有 \themename\ 独占的功能都已经用星号 $^*$ 标记。在迁移到其他的主题时，您需要手动重定向这些独占命令。这些独占命令已经通过 VS Code Snippets 的形式提供代码补全提示。
 
 \begin{table}[h]
   \centering

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -168,7 +168,7 @@ For those who are familiar with \verb"makefile" system, the following command mi
 
 \section{Coding Style}
 
-This section gives a contribution code on coding style. Every contributor should follow this coding style if you want to make a pull request to this project.
+This section gives a contribution code on coding style. Every contributor should follow this coding style if you want to make a pull request to this project. And following the coding style strictly will make the Doc\TeX{} compiler for Visual Studio Code snippets run properly.
 
 \subsection{Framework Code}
 

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/10/29 sjtubeamer color theme v2.3.0]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/11/22 sjtubeamer color theme v2.3.1]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2021/11/22 sjtubeamer color theme v2.3.1]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2021/11/22 sjtubeamer color theme v2.3.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/11/22 sjtubeamer font theme v2.3.1]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/11/22 sjtubeamer font theme v2.3.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2021/10/29 sjtubeamer font theme v2.3.0]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2021/11/22 sjtubeamer font theme v2.3.1]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/11/22 sjtubeamer inner theme v2.3.1]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/11/22 sjtubeamer inner theme v2.3.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/10/29 sjtubeamer inner theme v2.3.0]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2021/11/22 sjtubeamer inner theme v2.3.1]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -465,7 +465,9 @@
 %   Use \verb"\highlight" macro for making contrast.
 %   Since beamer has deleted \verb"\paragraph" macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from \verb"article" class.
 %    \begin{macrocode}
-\def\paragraph#1{\highlight{#1}~}
+\providecommand{\paragraph}[1]{
+  \highlight{#1}~
+}
 %    \end{macrocode}
 % \end{macro}
 %

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/11/22 sjtubeamer outer theme v2.3.1]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/11/22 sjtubeamer outer theme v2.3.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2021/10/29 sjtubeamer outer theme v2.3.0]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2021/11/22 sjtubeamer outer theme v2.3.1]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/10/29 sjtubeamer parent theme v2.3.0]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/11/22 sjtubeamer parent theme v2.3.1]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2021/11/22 sjtubeamer parent theme v2.3.1]
+\ProvidesPackage{beamerthemesjtubeamer}[2021/11/22 sjtubeamer parent theme v2.3.2]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/10/29 cover library for sjtubeamer v2.3.0]
+\ProvidesPackage{sjtucover}[2021/11/22 cover library for sjtubeamer v2.3.1]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2021/11/22 cover library for sjtubeamer v2.3.1]
+\ProvidesPackage{sjtucover}[2021/11/22 cover library for sjtubeamer v2.3.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/11/22 Visual Identity System library for sjtubeamer v2.3.1]
+\ProvidesPackage{sjtuvi}[2021/11/22 Visual Identity System library for sjtubeamer v2.3.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2021/10/29 Visual Identity System library for sjtubeamer v2.3.0]
+\ProvidesPackage{sjtuvi}[2021/11/22 Visual Identity System library for sjtubeamer v2.3.1]
 %</package>
 % \fi
 % \CheckSum{0}
@@ -203,9 +203,9 @@
 % \end{macro}
 %
 % \begin{macro}{\stamparray}
-%	  Create the stamp array in the TikZ environment.
+%   Create the stamp array in the TikZ environment.
 %
-%	  Notice \TeX{} is not good at handling parameters. Always remember to store it into a temporary variable. Register \verb"\pgfmathresult" will store the result of \verb"\pgfmathparse".
+%   Notice \TeX{} is not good at handling parameters. Always remember to store it into a temporary variable. Register \verb"\pgfmathresult" will store the result of \verb"\pgfmathparse".
 %    \begin{macrocode}
 \providecommand{\stamparray}[3]{
   % #1: pattern size


### PR DESCRIPTION
该 PR 添加了对于 dtx 文件的 [VS Code Snippets](https://code.visualstudio.com/docs/editor/userdefinedsnippets) 编译器。在 `l3build check` 阶段生成。

![snippet](https://user-images.githubusercontent.com/61653082/142800852-e3e4275a-8969-4909-82ca-2aae289911c3.gif)

`.vscode/sjtubeamer.code-snippets` 文件在 `l3build check` 阶段生成，会在输入对应的触发前缀（prefix）时提供代码补全提示，提示内容根据 `macro` 环境的第一段内容生成（`macrocode` 之前的内容）。为了让这个简易的编译器正常运行，源代码（dtx）需要遵循开发文档中的代码风格规则。

> beamer 自身的 snippets 由 [LaTeX-Workshop](https://github.com/James-Yu/LaTeX-Workshop) 扩展提供。
> 按照道理，模板不应当在编辑器上有偏好，专有编辑器如 TeX Studio, TeX Works 并没有提供类似的扩展方法，其他的编辑器如 Vim 等或许会在未来的一些时机通过 [Language Server Protocol](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide) 以获得跨编辑器的代码补全支持（还在考虑）。
> 发布包不包含 code snippets。