### PR TITLE
refactor: logo color system

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -29,12 +29,6 @@
 		"body": "\\sjtubeamer@inner@color",
 		"description": ""
 	},
-	"logo": {
-		"scope": "doctex,tex,latex",
-		"prefix": "\\logo",
-		"body": "\\logo{$1}",
-		"description": "Define logo.\n"
-	},
 	"bgcenterbox": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\bgcenterbox",
@@ -45,7 +39,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\\titlegraphic",
 		"body": "\\titlegraphic{$1}",
-		"description": " Define the title grahic image.\n\n NOTICE: if you are using your own title graphic, please use png image with predefined color and transparency. Since it is beyond the control of logo color system. Or you could use the provided command in the sjtuvi library to create your own masked picture in order to follow the logo color system (The provided picture should be white and transparent in the background).\n\nmax theme has the background.\n\\setbeamertemplate{background}{} after loading the theme will disable it.\n"
+		"description": " Define the title grahic image.\n\n TODO: TO BE DEPRECATED: NOTICE: if you are using your own title graphic, please use png image with predefined color and transparency. Since it is beyond the control of logo color system. Or you could use the provided command in the sjtuvi library to create your own masked picture in order to follow the logo color system (The provided picture should be white and transparent in the background).\n\nmax theme has the background.\n\\setbeamertemplate{background}{} after loading the theme will disable it.\n"
 	},
 	"coverpage": {
 		"scope": "doctex,tex",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -29,12 +29,6 @@
 		"body": "\\sjtubeamer@inner@color",
 		"description": ""
 	},
-	"sjtubeamer@logocolor": {
-		"scope": "doctex,tex",
-		"prefix": "\\sjtubeamer@logocolor",
-		"body": "\\sjtubeamer@logocolor",
-		"description": "Change the color variable that controls the logo color to current main color of this theme. Since this template doesn't design a dark background for the contents (it is really not easy to handle with the contents for a dark background).\n"
-	},
 	"logo": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\logo",
@@ -57,7 +51,7 @@
 		"scope": "doctex,tex",
 		"prefix": "\\coverpage",
 		"body": "\\coverpage{$1}",
-		"description": "Common command for \\titlepage and \\bottompage. Disable externalization for generating title page and bottom page, locally.\nSince the definition on \\sjtubeamer@logocolor is defined in a group, the stack is not necessary to store the value.\n"
+		"description": "Common command for \\titlepage and \\bottompage. Disable externalization for generating title page and bottom page, locally.\n"
 	},
 	"definecover": {
 		"scope": "doctex,tex",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -33,13 +33,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\\bgcenterbox",
 		"body": "\\bgcenterbox{$1}",
-		"description": "Define a command for USERS to make a centered background box easily. \nThe change on color is now deprecated.\n"
-	},
-	"titlegraphic": {
-		"scope": "doctex,tex,latex",
-		"prefix": "\\titlegraphic",
-		"body": "\\titlegraphic{$1}",
-		"description": " Define the title grahic image.\n\n TODO: TO BE DEPRECATED: NOTICE: if you are using your own title graphic, please use png image with predefined color and transparency. Since it is beyond the control of logo color system. Or you could use the provided command in the sjtuvi library to create your own masked picture in order to follow the logo color system (The provided picture should be white and transparent in the background).\n\nmax theme has the background.\n\\setbeamertemplate{background}{} after loading the theme will disable it.\n"
+		"description": "Define a command to make a centered background box easily.\n"
 	},
 	"coverpage": {
 		"scope": "doctex,tex",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/16 sjtubeamer color theme v2.5.1]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/18 sjtubeamer color theme v2.5.2]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -57,10 +57,10 @@
 \setbeamercolor{titlelike}{bg=,fg=cprimary}
 \setbeamercolor{title}{use={palette primary},fg=palette primary.fg,bg=}
 \setbeamercolor{subtitle}{use={palette secondary},fg=palette secondary.fg,bg=}
-\setbeamercolor{logo}{use={palette primary},bg=,fg=palette primary.fg}
-\setbeamercolor{author}{parent=logo}
-\setbeamercolor{institute}{parent=logo}
-\setbeamercolor{date}{parent=logo}
+\setbeamercolor{author}{use={palette primary},bg=,fg=palette primary.fg}
+\setbeamercolor{institute}{parent=author}
+\setbeamercolor{date}{parent=author}
+\setbeamercolor{logo}{bg=,fg=cprimary}
 \setbeamercolor{block title}{fg=white,bg=cprimary!90}
 \setbeamercolor{block title alerted}{use=alerted text,
   fg=white,bg=csecondary}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/16 sjtubeamer font theme v2.5.1]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/18 sjtubeamer font theme v2.5.2]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -54,7 +54,6 @@
   \colorlet{ctertiary}{sjtuBlueTertiary}
   \colorlet{cquanternary}{white}
 \fi
-\def\sjtubeamer@logocolor{cprimary}
 \RequirePackage{tcolorbox}
 \tcbuselibrary{skins}
 \tcbuselibrary{listingsutf8}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/16 sjtubeamer inner theme v2.5.1]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/18 sjtubeamer inner theme v2.5.2]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -58,16 +58,6 @@
 \tcbuselibrary{skins}
 \tcbuselibrary{listingsutf8}
 \tcbset{shield externalize}
-\usebeamercolor{palette primary}
-\if\EqualOption{inner}{cover}{max}
-  \logo{\resizebox{!}{1cm}{\sjtubadge}}
-\else
-  \if\EqualOption{inner}{lang}{cn}
-    \logo{\resizebox{!}{0.7cm}{\cnlogo}}
-  \else
-    \logo{\resizebox{!}{0.7cm}{\enlogo}}
-  \fi
-\fi
 \newcommand{\bgcenterbox}[1]{
   \parbox[c][1.1\paperheight][c]{\paperwidth}{
     \centering\resizebox{\paperwidth}{!}{#1}
@@ -96,6 +86,7 @@
   \fi
 \fi
 \RequirePackage{sjtucover}
+\setbeamertemplate{logo}[\sjtubeamer@inner@cover]
 \newdimen\beamer@sidebarwidth
 \beamer@sidebarwidth=0pt
 \def\coverpage#1{

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -58,35 +58,20 @@
 \tcbuselibrary{skins}
 \tcbuselibrary{listingsutf8}
 \tcbset{shield externalize}
+\RequirePackage{sjtucover}
+\setbeamertemplate{logo}[\sjtubeamer@inner@cover]
 \newcommand{\bgcenterbox}[1]{
   \parbox[c][1.1\paperheight][c]{\paperwidth}{
     \centering\resizebox{\paperwidth}{!}{#1}
   }
 }
-\if\EqualOption{inner}{cover}{maxplus}
-  \titlegraphic{\includegraphics{vi/sjtuphoto.jpg}}
-\else
-  \if\EqualOption{inner}{cover}{max}
-    \usebeamercolor{palatte primary}
-    \titlegraphic{\sjtubg[opacity=0.2]}
-    \setbeamertemplate{background}
+\if\EqualOption{inner}{cover}{max}
+  \setbeamertemplate{background}
     {\bgcenterbox{\sjtubg[cprimary!50,opacity=0.2]}}
-  \else
-    \if\EqualOption{inner}{cover}{min}
-      \titlegraphic{\includegraphics{vi/sjtuphoto.jpg}}
-    \else
-      \if\EqualOption{inner}{cover}{my}
-        %
-        % Developer could define your title graphic here for "my"...
-        %
-        \titlegraphic{}
-      \else
-      \fi
-    \fi
-  \fi
 \fi
-\RequirePackage{sjtucover}
-\setbeamertemplate{logo}[\sjtubeamer@inner@cover]
+\def\titlegraphic{\setbeamertemplate{titlegraphic}}
+\def\inserttitlegraphic{\usebeamertemplate{titlegraphic}}
+\setbeamertemplate{titlegraphic}[\sjtubeamer@inner@cover]
 \newdimen\beamer@sidebarwidth
 \beamer@sidebarwidth=0pt
 \def\coverpage#1{

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -71,6 +71,7 @@
 \fi
 \def\titlegraphic{\setbeamertemplate{titlegraphic}}
 \def\inserttitlegraphic{\usebeamertemplate{titlegraphic}}
+\setbeamertemplate{titlegraphic}{}
 \setbeamertemplate{titlegraphic}[\sjtubeamer@inner@cover]
 \newdimen\beamer@sidebarwidth
 \beamer@sidebarwidth=0pt

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/16 sjtubeamer outer theme v2.5.1]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/18 sjtubeamer outer theme v2.5.2]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -70,7 +70,7 @@
         \begingroup
         \ifx\insertframesubtitle\@empty\vskip-2.5ex%
         \else\vskip-3.5ex\fi%
-        \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}\hspace*{5pt}%
+        \resizebox{!}{0.7cm}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{5pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
         \else\vskip0.5ex\fi%

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/02/16 sjtubeamer parent theme v2.5.1]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/02/18 sjtubeamer parent theme v2.5.2]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/contrib/sjtug/sjtubeamerthemesjtug.ltx
+++ b/contrib/sjtug/sjtubeamerthemesjtug.ltx
@@ -28,7 +28,7 @@
 % 设置背景为 SJTUG 文字
 \setbeamertemplate{background}{
   \bgcenterbox{
-    \sjtugtext[opacity=0.1]
+    \sjtugtext[cprimary, opacity=0.1]
   }
 }
 % 判断传递的选项

--- a/contrib/sjtug/sjtubeamerthemesjtug.ltx
+++ b/contrib/sjtug/sjtubeamerthemesjtug.ltx
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 % 设置文件元数据
-\ProvidesFile{sjtubeamerthemesjtug.ltx}[2022/01/30 SJTUG subtheme for SJTUBeamer]
+\ProvidesFile{sjtubeamerthemesjtug.ltx}[2022/02/18 SJTUG subtheme for SJTUBeamer]
 % 设置组织名称
 \institute[SJTU Linux User Group]{上海交通大学 Linux 用户组}
 % 设置徽标

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/02/16 cover library for sjtubeamer v2.5.1]
+\ProvidesPackage{sjtucover}[2022/02/18 cover library for sjtubeamer v2.5.2]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{cn}
 \DefineOption{cover}{lang}{en}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -31,6 +31,14 @@
 \else
   \defbeamertemplate*{logo}{default}{\resizebox{!}{0.7cm}{\enlogo}}
 \fi
+\defbeamertemplate*{titlegraphic}{maxplus}{\includegraphics{vi/sjtuphoto.jpg}}
+\defbeamertemplate*{titlegraphic}{max}{\sjtubg[opacity=0.2]}
+\defbeamertemplate*{titlegraphic}{min}{\includegraphics{vi/sjtuphoto.jpg}}
+\defbeamertemplate*{titlegraphic}{my}{
+  %
+  % Developer could define your title graphic here for "my"...
+  %
+}
 \defbeamertemplate*{title page}{maxplus}[1][]
 {
   \nointerlineskip%

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -25,6 +25,12 @@
 \@ifclassloaded{ctexbeamer}{\ExecuteOptionsBeamer{cn}}{
   \ExecuteOptionsBeamer{en}}
 \ProcessOptionsBeamer
+\defbeamertemplate*{logo}{max}{\resizebox{!}{1cm}{\sjtubadge}}
+\if\EqualOption{cover}{lang}{cn}
+  \defbeamertemplate*{logo}{default}{\resizebox{!}{0.7cm}{\cnlogo}}
+\else
+  \defbeamertemplate*{logo}{default}{\resizebox{!}{0.7cm}{\enlogo}}
+\fi
 \defbeamertemplate*{title page}{maxplus}[1][]
 {
   \nointerlineskip%
@@ -222,8 +228,6 @@
   % and in the main.tex:
   %    \usetheme[my]{sjtubeamer}\usepackage{mycover}
   %
-  % Remember the change on logo color is temporary,
-  % which will be restored after rendering this page.
 }
 \if\EqualOption{cover}{lang}{cn}%
   \newcommand{\bottomthanks}{谢\,谢}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -32,7 +32,6 @@
   \vfill
   \begingroup
   \usebeamercolor{palette primary}%
-  \def\sjtubeamer@logocolor{palette primary.fg}
   \begin{tikzpicture}[overlay,
       xshift=-0.12\paperwidth,
       yshift=-0.53\paperheight]
@@ -58,7 +57,8 @@
         {\usebeamercolor[fg]{date}\small\insertdate}%
     };
     \node[anchor=south east, inner sep=0, outer sep=0] at (\outslant,0.5){
-      \resizebox{!}{1cm}{\insertlogo}
+      \usebeamercolor[fg]{palatte primary}
+      \resizebox{!}{1cm}{\usebeamertemplate{logo}}
     };
   \end{tikzpicture}
   \endgroup
@@ -69,11 +69,10 @@
   \nointerlineskip
   \vbox{}
   \usebeamercolor{palette primary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
     rectangle (1*\the\paperwidth, 0.3*\the\paperheight);
-    \node [inner sep=0pt]
+    \node [palette primary.fg, inner sep=0pt]
     at (0.45\paperwidth-6pt,-0.4*\the\paperheight)
     {\resizebox{1.3\paperwidth}{!}{\inserttitlegraphic}};
   \end{tikzpicture}
@@ -117,7 +116,6 @@
 {
   \vbox{}
   \usebeamercolor{palette primary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
     rectangle (1*\the\paperwidth, 0.2*\the\paperheight);
@@ -141,11 +139,10 @@
   \vfill
   \begingroup
   \centering
-  \usebeamercolor{titlelike}
-  \begin{beamercolorbox}{logo}
+  \begin{beamercolorbox}{palette primary}
     \vskip8pt
     \hbox{
-      \hskip-4pt{\resizebox{!}{1cm}{\insertlogo}}
+      \hskip-4pt{\resizebox{!}{1cm}{\usebeamertemplate{logo}}}
       \ifx\insertinstitute\@empty%
       \else
       \ifx\insertlogo\@empty%
@@ -227,8 +224,6 @@
   %
   % Remember the change on logo color is temporary,
   % which will be restored after rendering this page.
-  \usebeamercolor{palette primary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
 }
 \if\EqualOption{cover}{lang}{cn}%
   \newcommand{\bottomthanks}{谢\,谢}
@@ -250,7 +245,6 @@
   \vfill
   \begin{beamercolorbox}[sep=0pt]{empty}
     \usebeamercolor{structure}
-    \def\sjtubeamer@logocolor{white}
     \begin{tikzpicture}[overlay,xshift=0.54\paperwidth,yshift=-0.41\paperheight]
       \begin{scope}
         \clip (-0.66\paperwidth,0.06\paperheight)
@@ -260,8 +254,8 @@
         \fill[structure.fg!50!black,path fading=fade right img]
         (-0.66\paperwidth,0.06\paperheight)
         rectangle (0.43\paperwidth,0.53\paperheight);
-        \node at (-0.45\paperwidth,0.3\paperheight)
-        {\resizebox{!}{0.115\paperheight}{\insertlogo}};
+        \node[white] at (-0.45\paperwidth,0.3\paperheight)
+        {\resizebox{!}{0.115\paperheight}{\usebeamertemplate{logo}}};
         \draw[white] (-0.66\paperwidth,0.1\paperheight)
         -- (0.43\paperwidth,0.1\paperheight);
       \end{scope}
@@ -297,12 +291,10 @@
       -- (\rightw,-0.59\paperheight)
       -- (\rightw,-0.53\paperheight)
       -- (\midw,-0.68\paperheight) -- cycle;
-      \node at (\midw,-0.65\paperheight) {
-        \def\sjtubeamer@logocolor{black}
+      \node[black] at (\midw,-0.65\paperheight) {
         \resizebox{1.25\paperwidth}{!}{\inserttitlegraphic}};
       \node at (\midw,-0.2\paperheight) {
-        \def\sjtubeamer@logocolor{palette primary.bg}
-        \resizebox{3cm}{!}{\insertlogo}};
+        \resizebox{3cm}{!}{\usebeamertemplate{logo}}};
       \node at (\midw,-0.45\paperheight) {
         \usebeamercolor[bg]{palette primary}
         \LARGE \bfseries\bottomthanks};
@@ -314,7 +306,6 @@
   \vbox{}
   \usebeamercolor{palette primary}
   \usebeamercolor{palette secondary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
   \begin{tikzpicture}[overlay,yshift=-80pt]
     \def\w{\the\paperwidth}%
     \def\h{\the\paperheight}%
@@ -333,13 +324,13 @@
     \end{scope}
   \end{tikzpicture}
   \vfill
+  \usebeamercolor[fg]{palette primary}
   \begingroup
   \raggedleft
-  \resizebox{!}{1cm}{\insertlogo}
+  \resizebox{!}{1cm}{\usebeamertemplate{logo}}
   \vfill
   \vskip6em
   \begin{beamercolorbox}[sep=8pt]{title}
-    \usebeamercolor[fg]{palette primary}
     \usebeamerfont{title}\noindent\bottomthanks
     \vskip1em%
     \usebeamerfont{subtitle}
@@ -366,10 +357,6 @@
   % and in the main.tex:
   %    \usetheme[my]{sjtubeamer}\usepackage{mycover}
   %
-  % Remember the change on logo color is temporary,
-  % which will be restored after rendering this page.
-  \usebeamercolor{palette primary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
 }
 \defbeamertemplate*{part page}{min}[1][]
 {

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -51,8 +51,8 @@
       yshift=-0.53\paperheight]
     \pgfmathsetlengthmacro{\outslant}{1.02\paperwidth}
     \node[inner sep=0, outer sep=0]
-    at (0.57\paperwidth,0.5\paperheight){
-      \resizebox{!}{1.06\paperheight}{\inserttitlegraphic}};
+      at (0.57\paperwidth,0.5\paperheight){
+        \resizebox{!}{1.06\paperheight}{\vphantom{-}\inserttitlegraphic}};
     \fill[color=white] (0,0) rectangle(1.1\paperwidth,3.9);
     \fill[color=bg]  (0,-0.1\paperheight) rectangle(1.1\paperwidth,3.88);
     \node[anchor=north west, text width=.8\paperwidth]
@@ -72,7 +72,7 @@
     };
     \node[anchor=south east, inner sep=0, outer sep=0] at (\outslant,0.5){
       \usebeamercolor[fg]{palatte primary}
-      \resizebox{!}{1cm}{\usebeamertemplate{logo}}
+      \resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}
     };
   \end{tikzpicture}
   \endgroup
@@ -156,7 +156,7 @@
   \begin{beamercolorbox}{palette primary}
     \vskip8pt
     \hbox{
-      \hskip-4pt{\resizebox{!}{1cm}{\usebeamertemplate{logo}}}
+      \hskip-4pt{\resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}}
       \ifx\insertinstitute\@empty%
       \else
       \ifx\insertlogo\@empty%
@@ -267,7 +267,7 @@
         (-0.66\paperwidth,0.06\paperheight)
         rectangle (0.43\paperwidth,0.53\paperheight);
         \node[white] at (-0.45\paperwidth,0.3\paperheight)
-        {\resizebox{!}{0.115\paperheight}{\usebeamertemplate{logo}}};
+        {\resizebox{!}{0.115\paperheight}{\vphantom{-}\usebeamertemplate{logo}}};
         \draw[white] (-0.66\paperwidth,0.1\paperheight)
         -- (0.43\paperwidth,0.1\paperheight);
       \end{scope}
@@ -306,7 +306,7 @@
       \node[black] at (\midw,-0.65\paperheight) {
         \resizebox{1.25\paperwidth}{!}{\inserttitlegraphic}};
       \node at (\midw,-0.2\paperheight) {
-        \resizebox{3cm}{!}{\usebeamertemplate{logo}}};
+        \resizebox{3cm}{!}{\hphantom{-}\usebeamertemplate{logo}}};
       \node at (\midw,-0.45\paperheight) {
         \usebeamercolor[bg]{palette primary}
         \LARGE \bfseries\bottomthanks};
@@ -339,7 +339,7 @@
   \usebeamercolor[fg]{palette primary}
   \begingroup
   \raggedleft
-  \resizebox{!}{1cm}{\usebeamertemplate{logo}}
+  \resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}
   \vfill
   \vskip6em
   \begin{beamercolorbox}[sep=8pt]{title}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -65,19 +65,18 @@
       \node {\includegraphics[height=1.5cm]{#1/#2}};
     \end{tikzfadingfrompicture}
   \fi
-  \expandafter\providecommand\csname #2\endcsname[1][\sjtubeamer@logocolor]{
+  \expandafter\providecommand\csname #2\endcsname[1][]{
     % ##1: override color, or opacity=... (optional)
     \tikzexternaldisable
     \begin{tikzpicture}
       \begin{scope}
         \clip ({-1.0+#3},{-1.0+#4}) rectangle ({1.0-#3},{1.0-#4});
-        \fill [\sjtubeamer@logocolor, ##1, path fading=#2]
+        \fill [##1, path fading=#2]
           (-1,-1) rectangle (1,1);
       \end{scope}
     \end{tikzpicture}
   }
 }
-\def\sjtubeamer@logocolor{sjtuRedPrimary}
 \definelogo{sjtubadge}{0}{0}
 \definelogo{cnlogo}{0.13}{0.75}
 \definelogo{enlogo}{0.13}{0.75}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/02/16 Visual Identity System library for sjtubeamer v2.5.1]
+\ProvidesPackage{sjtuvi}[2022/02/18 Visual Identity System library for sjtubeamer v2.5.2]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -463,7 +463,7 @@ fontupper=\sffamily,colupper=white}
 
 \begin{commentlist}
   \item 使用 \texttt{\textbackslash{}logo} 设定徽标。在主题处使用 \verb"topright" 或 \verb"bottomright" 选项强制指定徽标的位置为右上角（\verb"max"默认）或左下角（\verb"maxplus" 和 \verb"min"）。
-  \item 可以使用自定义的徽标，但是不归 \themename 颜色系统管理$^*$，此时推荐使用亮色主题以提供亮色徽标背景。或参见\href{run:sjtubeamerdevguide.pdf}{开发指南}第 3.4 节创造可变颜色徽标$^*$。
+  \item 可以使用自定义的徽标，可以使用外部图片，或参见\href{run:sjtubeamerdevguide.pdf}{开发指南}第 3.4 节创造可变颜色徽标$^*$。后者可以采用可选参数改变颜色，比如 \texttt{\textbackslash{}cnlogo[cprimary]}。
 \end{commentlist}
 
 \chapter{头图}
@@ -475,7 +475,7 @@ fontupper=\sffamily,colupper=white}
 \begin{commentlist}
   \item 使用 \texttt{\textbackslash{}titlegraphic} 设定头图，需要在封面图输出前进行赋值。
   \item 每个主题的头图位置不同，特别要注意默认的 \texttt{max} 主题的头图是淡色背景图。
-  \item 对头图可以不设定大小，因为会自动占满占位符。
+  \item 对头图可以不设定大小，因为会自动填满占位符。
 \end{commentlist}
 
 \chapter{背景}

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -266,8 +266,8 @@ Kernel function means that it is not recommended to be used by end users.
 \paragraph{If your definition has an optional parameter, use \LaTeX\ style.} The maximum number of the optional parameter is 1 only. You cannot have more optional parameters. Give the default optional parameter in the second square brackets.
 
 \begin{lstlisting}
-\expandafter\providecommand\csname #1\endcsname
-    [1][\sjtubeamer@logocolor]{}
+\expandafter\providecommand\csname #2\endcsname
+    [1][]{}
     \end{lstlisting}
 
 \subparagraph{Pros:} Using this method could get an optional parameter.
@@ -305,7 +305,7 @@ Global variable means that it will be used across modules.
 \end{itemize}
 
 \begin{lstlisting}
-\def\sjtubeamer@logocolor{sjtuRedPrimary}
+\def\sjtubeamer@inner@lang{en}
     \end{lstlisting}
 
 \subparagraph{Pros:} Make a clear visual indication of the variable type and avoid duplicates with other packages.
@@ -388,22 +388,20 @@ Paste it and change \verb"my" to your name of your template. And add the precomp
 
 \subparagraph{Decision:} Follow the rule to submit your template.
 
-\subsubsection{Logo Color System}
+\subsubsection{Logo Insertion}\label{sec:logoins}
 
-\paragraph{Change the variable to change the logo color.} This will change the \emph{temporary} variable of the logo color to fit with different scenarios.
+Use a \verb"\resizebox" to resize the logo into the required width and height. If you want to keep one dimension in the same ratio, use the placeholder \verb"!".
 
-\begin{lstlisting}
-\def\sjtubeamer@logocolor{palette primary.fg}
-    \end{lstlisting}
-
-What's more, you should always use the placeholder to insert your logo, surrounded by a size constraint.
+If you want to protect the logo color as the color definition in beamer color \verb"logo.fg", use \verb"\insertlogo".
 \begin{lstlisting}
 \resizebox{!}{1cm}{\insertlogo}
     \end{lstlisting}
 
-\begin{warn}
-  Logo and title graphic share this variable in the color system. Be sure to change the color before you make those placeholders.
-\end{warn}
+Otherwise, if you want to use the color that is current to the text, use \verb"\usebeamertemplate{logo}". If you want to modify the current text color, either use \verb"\usebeamercolor" for beamer color, or \verb"\color" for regular xcolor.
+\begin{lstlisting}
+\usebeamercolor[fg]{palette primary}
+\resizebox{!}{1cm}{\usebeamertemplate{logo}}
+    \end{lstlisting}
 
 \subsection{Comment}
 
@@ -517,20 +515,18 @@ The table shows the flow of parameter passing.
   \texttt{\textbackslash{}maketitle{[}maxplus{]}}\par
   ~~$\hookrightarrow $set title template to \texttt{maxplus}\par
   ~~\hspace*{2em}\texttt{\textbackslash{}titlepage}\par
-  ~~\hspace*{2em} $\hookrightarrow $ store the old \texttt{\textbackslash{}...@logocolor}\par
   ~~\hspace*{4em} in sidebar mode, make a left shift\par
   ~~\hspace*{4em} $\hookrightarrow $ insert the defined title page (in \verb"sjtucover.sty")\par
-  ~~\hspace*{4em}restore \texttt{\textbackslash{}...@logocolor}\par
   ~~\hspace*{1em}restore title template back to \texttt{\textbackslash{}...@inner@cover}
 \end{figure}
 
-Now, a sandbox in \verb"sjtucover.sty" is created. The modification on logo color is temporary and your page insertion aside from the current theme is also temporary.
+Now, a sandbox in \verb"sjtucover.sty" is created.
 
 \begin{warn}
   When drawing in the sandbox through Ti\emph{k}Z, make sure to use \texttt{overlay} option for adjustment. It will avoid the shift of your cover when using \texttt{sidebar} theme.
 \end{warn}
 
-Since large source code may cause a performance drop on compiling. We have figure out a precompiling mechanism to reduce the templates it generates. See Section \ref{sec:precompile}.
+Since large source code may cause a performance drop on compiling. We have figured out a precompiling mechanism to reduce the templates it generates. See Section \ref{sec:precompile}.
 
 You could also make your customized style by using \texttt{my} option to setup all components from scratch without leaving the \themename\ ecosystem with all those utilities.
 
@@ -542,7 +538,7 @@ errors, you have to assign the placeholder for a correct resizing. And if you re
 
 You could refer to the user guide for a sample file. And the loading on the package is not that necessary as long as you load the theme before it is loaded, which is only for the sake of completeness.
 
-\subsection{Logo Color System}
+\subsection{Logo System}
 
 \themename\ has its own color model on logo. The main macro is \verb"\definelogo", which will generate a macro on its file name.
 
@@ -568,9 +564,9 @@ However, this only creates a square mask. We have to crop it for some rectangula
   \end{tikzpicture}
 \end{figure}
 
-And the logo color is controlled by a global variable \verb"\sjtubeamer@logocolor". It can be overridden by an optional parameter when you insert your logo.
+Remember, you have to store the picture in a specific folder to create a mask. It is by default \verb"vi". You could use the optional argument of \verb"\definelogo" for switching to another folder.
 
-Remember, you have to store the picture in the \texttt{vi/} folder to create a mask.
+The logo color is now controlled by the current text color. See Section \ref{sec:logoins} for how to modify the logo color for \verb"\insertlogo". The generated command can also receive an optional command for overriding color or changing opacity or use any supported Ti\emph{k}Z argument for \verb"\fill".
 
 \section{Compatibility}
 

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -560,13 +560,13 @@ However, this only creates a square mask. We have to crop it for some rectangula
     \node at (4,0) {$\rightarrow$};
 
     \node [blue] at (6,0) {\LARGE Logo};
-    \node at (6,-1.5) {\verb"\logo[blue]"};
+    \node at (6,-1.5) {\verb"\logo[cprimary]"};
   \end{tikzpicture}
 \end{figure}
 
 Remember, you have to store the picture in a specific folder to create a mask. It is by default \verb"vi". You could use the optional argument of \verb"\definelogo" for switching to another folder.
 
-The logo color is now controlled by the current text color. See Section \ref{sec:logoins} for how to modify the logo color for \verb"\insertlogo". The generated command can also receive an optional command for overriding color or changing opacity or use any supported Ti\emph{k}Z argument for \verb"\fill".
+The logo color is now controlled by the current text color. See Section \ref{sec:logoins} for how to modify the logo color for \verb"\insertlogo". Otherwise, the generated command can also receive an optional command for overriding color or changing the opacity or using any supported Ti\emph{k}Z argument for \verb"\fill". Sometimes, you need to specify the color for your logo object.
 
 \section{Compatibility}
 

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -100,6 +100,7 @@
 %    \end{macrocode}
 %
 %   Logo color system is now controlled by \verb"logo.fg".
+%   If you want to use a logo with its color definition in \verb"logo", use \verb"\insertlogo". Otherwise, if you want to use a logo that matches the current text color, use \verb"\usebeamertemplate{logo}".
 %    \begin{macrocode}
 \setbeamercolor{logo}{bg=,fg=cprimary}
 %    \end{macrocode}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -94,10 +94,14 @@
 \setbeamercolor{titlelike}{bg=,fg=cprimary}
 \setbeamercolor{title}{use={palette primary},fg=palette primary.fg,bg=}
 \setbeamercolor{subtitle}{use={palette secondary},fg=palette secondary.fg,bg=}
-\setbeamercolor{logo}{use={palette primary},bg=,fg=palette primary.fg}
-\setbeamercolor{author}{parent=logo}
-\setbeamercolor{institute}{parent=logo}
-\setbeamercolor{date}{parent=logo}
+\setbeamercolor{author}{use={palette primary},bg=,fg=palette primary.fg}
+\setbeamercolor{institute}{parent=author}
+\setbeamercolor{date}{parent=author}
+%    \end{macrocode}
+%
+%   Logo color system is now controlled by \verb"logo.fg".
+%    \begin{macrocode}
+\setbeamercolor{logo}{bg=,fg=cprimary}
 %    \end{macrocode}
 %
 %   This part defines the color of block title.

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/16 sjtubeamer color theme v2.5.1]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/18 sjtubeamer color theme v2.5.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/16 sjtubeamer font theme v2.5.1]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/18 sjtubeamer font theme v2.5.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -177,7 +177,9 @@
 %    \end{macrocode}
 %
 %   Set up titlegraphic for this cover.
+%   First set to empty in case that all definitions of this template in \verb"sjtucover" is not extracted.
 %    \begin{macrocode}
+\setbeamertemplate{titlegraphic}{}
 \setbeamertemplate{titlegraphic}[\sjtubeamer@inner@cover]
 %    \end{macrocode}
 %

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -122,7 +122,7 @@
 \fi
 %    \end{macrocode}
 %
-%   \subsubsection{Load Packages}
+%   \subsubsection{Load Packages}\label{sec:innerload}
 %
 %   Introduce the library from tcolorbox to make code blocks.
 %   \verb"listingsutf8" is used to receive UTF-8 input. 
@@ -134,11 +134,20 @@
 \tcbset{shield externalize}
 %    \end{macrocode}
 %
-% \subsubsection{Title Page \& Bottom Page}
+%   Load Cover Library to get the customized cover.
+%    \begin{macrocode}
+\RequirePackage{sjtucover}
+%    \end{macrocode}
+%
+%   \subsubsection{Logo \& Title Graphic}
+%
+%   Set up logo for this cover.
+%    \begin{macrocode}
+\setbeamertemplate{logo}[\sjtubeamer@inner@cover]
+%    \end{macrocode}
 %
 %  \begin{macro}{\bgcenterbox}
-%   Define a command for USERS to make a centered background box easily. 
-%   The change on color is now deprecated.
+%   Define a command to make a centered background box easily.
 %    \begin{macrocode}
 \newcommand{\bgcenterbox}[1]{
   \parbox[c][1.1\paperheight][c]{\paperwidth}{
@@ -148,64 +157,32 @@
 %    \end{macrocode}
 %  \end{macro}
 %
-%  \begin{macro}{\titlegraphic}
-% Define the title grahic image.
-%
-% TODO: TO BE DEPRECATED: NOTICE: if you are using your own title graphic, please use png image with predefined color and transparency. Since it is beyond the control of logo color system. Or you could use the provided command in the sjtuvi library to create your own masked picture in order to follow the logo color system (The provided picture should be white and transparent in the background).
-%
-%    max theme has the background.
-%    \verb"\setbeamertemplate{background}{}" after loading the theme will disable it.
+%   max theme has the background.
+%   \verb"\setbeamertemplate{background}{}" after loading the theme will disable it.
 %    \begin{macrocode}
-%<*maxplus>
-\if\EqualOption{inner}{cover}{maxplus}
-  \titlegraphic{\includegraphics{vi/sjtuphoto.jpg}}
-\else
-%</maxplus>
-%<*max>
-  \if\EqualOption{inner}{cover}{max}
-    \usebeamercolor{palatte primary}
-    \titlegraphic{\sjtubg[opacity=0.2]}
-    \setbeamertemplate{background}
+\if\EqualOption{inner}{cover}{max}
+  \setbeamertemplate{background}
     {\bgcenterbox{\sjtubg[cprimary!50,opacity=0.2]}}
-  \else
-%</max>
-%<*min>
-    \if\EqualOption{inner}{cover}{min}
-      \titlegraphic{\includegraphics{vi/sjtuphoto.jpg}}
-    \else
-%</min>
-%<*my>
-      \if\EqualOption{inner}{cover}{my}
-        %
-        % Developer could define your title graphic here for "my"...
-        %
-        \titlegraphic{}
-      \else
-%</my>
-%<*my>
-      \fi
-%</my>
-%<*min>
-    \fi
-%</min>
-%<*max>
-  \fi
-%</max>
-%<*maxplus>
 \fi
-%</maxplus>
-%    \end{macrocode}
-%  \end{macro}
-%
-%   Load Cover Library to get the customized cover.
-%    \begin{macrocode}
-\RequirePackage{sjtucover}
 %    \end{macrocode}
 %
-%   Set logo for this cover.
+%   Redefine the \verb"\titlegraphic" command in \verb"beamer" to implement it into the beamer template management system, as is been done in \verb"\logo".
+%   The original definition of \verb"\titlegraphic" is to set the command \verb"\inserttitlegraphic" as its parameter directly.
 %    \begin{macrocode}
-\setbeamertemplate{logo}[\sjtubeamer@inner@cover]
+\def\titlegraphic{\setbeamertemplate{titlegraphic}}
 %    \end{macrocode}
+%   Redefine the \verb"\inserttitlegraphic" command to use the template \verb"titlegraphic" directly, using the current color setup without forming a group (not \verb"\usebeamertemplate*").
+%    \begin{macrocode}
+\def\inserttitlegraphic{\usebeamertemplate{titlegraphic}}
+%    \end{macrocode}
+%
+%   Set up titlegraphic for this cover.
+%    \begin{macrocode}
+\setbeamertemplate{titlegraphic}[\sjtubeamer@inner@cover]
+%    \end{macrocode}
+%
+% \subsubsection{Covers.}
+%  This part set up title page, section page, part page, section page and subsection page for this cover based on the library \verb"sjtucover" loaded in section \ref{sec:innerload}.
 %
 %  Initialize sidebar width to 0pt as no sidebar required, which will be overwritten in outer theme.
 %    \begin{macrocode}
@@ -262,6 +239,7 @@
 %    \end{macrocode}
 %  \end{macro}
 %
+%   Set up commmand for title page and bottom page.
 %    \begin{macrocode}
 \definecover{title}
 \definecover{bottom}
@@ -273,9 +251,7 @@
 \setbeamertemplate{bottom page}[\sjtubeamer@inner@cover]
 %    \end{macrocode}
 %
-% \subsubsection{Sectioning Page}
 %   Set up commmand for part page, section page and subsection page.
-%
 %    \begin{macrocode}
 \definecover{part}
 \definecover{section}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -122,13 +122,6 @@
 \fi
 %    \end{macrocode}
 %
-%  \begin{macro}{\sjtubeamer@logocolor}
-%   Change the color variable that controls the logo color to current main color of this theme. Since this template doesn't design a dark background for the contents (it is really not easy to handle with the contents for a dark background).
-%    \begin{macrocode}
-\def\sjtubeamer@logocolor{cprimary}
-%    \end{macrocode}
-%  \end{macro}
-%
 %   \subsubsection{Load Packages}
 %
 %   Introduce the library from tcolorbox to make code blocks.
@@ -178,7 +171,7 @@
 %  \begin{macro}{\titlegraphic}
 % Define the title grahic image.
 %
-% NOTICE: if you are using your own title graphic, please use png image with predefined color and transparency. Since it is beyond the control of logo color system. Or you could use the provided command in the sjtuvi library to create your own masked picture in order to follow the logo color system (The provided picture should be white and transparent in the background).
+% TODO: TO BE DEPRECATED: NOTICE: if you are using your own title graphic, please use png image with predefined color and transparency. Since it is beyond the control of logo color system. Or you could use the provided command in the sjtuvi library to create your own masked picture in order to follow the logo color system (The provided picture should be white and transparent in the background).
 %
 %    max theme has the background.
 %    \verb"\setbeamertemplate{background}{}" after loading the theme will disable it.
@@ -237,7 +230,6 @@
 %
 %  \begin{macro}{\coverpage}
 %  Common command for \verb"\titlepage" and \verb"\bottompage". Disable externalization for generating title page and bottom page, locally.
-%  Since the definition on \verb"\sjtubeamer@logocolor" is defined in a group, the stack is not necessary to store the value.
 %    \begin{macrocode}
 \def\coverpage#1{
   {

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/16 sjtubeamer inner theme v2.5.1]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/18 sjtubeamer inner theme v2.5.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -183,7 +183,7 @@
 \setbeamertemplate{titlegraphic}[\sjtubeamer@inner@cover]
 %    \end{macrocode}
 %
-% \subsubsection{Covers.}
+% \subsubsection{Covers}
 %  This part set up title page, section page, part page, section page and subsection page for this cover based on the library \verb"sjtucover" loaded in section \ref{sec:innerload}.
 %
 %  Initialize sidebar width to 0pt as no sidebar required, which will be overwritten in outer theme.

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -136,26 +136,6 @@
 %
 % \subsubsection{Title Page \& Bottom Page}
 %
-%  \begin{macro}{\logo}
-%  Define logo.
-%    \begin{macrocode}
-\usebeamercolor{palette primary}
-%<*max>
-\if\EqualOption{inner}{cover}{max}
-  \logo{\resizebox{!}{1cm}{\sjtubadge}}
-\else
-%</max>
-  \if\EqualOption{inner}{lang}{cn}
-    \logo{\resizebox{!}{0.7cm}{\cnlogo}}
-  \else
-    \logo{\resizebox{!}{0.7cm}{\enlogo}}
-  \fi
-%<*max>
-\fi
-%</max>
-%    \end{macrocode}
-%  \end{macro}
-%
 %  \begin{macro}{\bgcenterbox}
 %   Define a command for USERS to make a centered background box easily. 
 %   The change on color is now deprecated.
@@ -220,6 +200,11 @@
 %   Load Cover Library to get the customized cover.
 %    \begin{macrocode}
 \RequirePackage{sjtucover}
+%    \end{macrocode}
+%
+%   Set logo for this cover.
+%    \begin{macrocode}
+\setbeamertemplate{logo}[\sjtubeamer@inner@cover]
 %    \end{macrocode}
 %
 %  Initialize sidebar width to 0pt as no sidebar required, which will be overwritten in outer theme.

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -110,7 +110,7 @@
 %    \end{macrocode}
 % Insert the outer logo with 0.7cm height. \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input. The calculation is fixed for a 0.7cm height logo placeholder.
 %    \begin{macrocode}
-        \resizebox{!}{0.7cm}{\vphantom{-}\insertlogo}\hspace*{5pt}%
+        \resizebox{!}{0.7cm}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{5pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
         \else\vskip0.5ex\fi%

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/16 sjtubeamer outer theme v2.5.1]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/18 sjtubeamer outer theme v2.5.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/02/16 sjtubeamer parent theme v2.5.1]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/02/18 sjtubeamer parent theme v2.5.2]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -60,8 +60,37 @@
 %    \end{macrocode}
 %
 %    \subsubsection{Title Graphic}
-%    \paragraph{max.}
+%    \paragraph{maxplus.}
+%    \begin{macrocode}
+%<*maxplus>
+\defbeamertemplate*{titlegraphic}{maxplus}{\includegraphics{vi/sjtuphoto.jpg}}
+%</maxplus>
+%    \end{macrocode}
 %
+%    \paragraph{max.}
+%    \begin{macrocode}
+%<*max>
+\defbeamertemplate*{titlegraphic}{max}{\sjtubg[opacity=0.2]}
+%</max>
+%    \end{macrocode}
+%
+%    \paragraph{min.}
+%    \begin{macrocode}
+%<*min>
+\defbeamertemplate*{titlegraphic}{min}{\includegraphics{vi/sjtuphoto.jpg}}
+%</min>
+%    \end{macrocode}
+%
+%    \paragraph{my.}
+%    \begin{macrocode}
+%<*my>
+\defbeamertemplate*{titlegraphic}{my}{
+  %
+  % Developer could define your title graphic here for "my"...
+  %
+}
+%</my>
+%    \end{macrocode}
 %
 %   \subsubsection{Title Page}
 %  
@@ -156,7 +185,6 @@
 %
 %   \paragraph{min.}
 %   Declare two fadings: center fade and fade right. The center fade provides a radial fading on the right side of the title page. The fade right provides a linear fading to avoid the collision on the text in the left.
-%   WARNING: Now it is not used in the titlepage.
 %    \begin{macrocode}
 %<*min>
 \tikzfading[

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -42,6 +42,27 @@
 \ProcessOptionsBeamer
 %    \end{macrocode}
 %
+%   \subsubsection{Logo}
+%   \paragraph{max.}
+%    \begin{macrocode}
+%<*max>
+\defbeamertemplate*{logo}{max}{\resizebox{!}{1cm}{\sjtubadge}}
+%</max>
+%    \end{macrocode}
+%
+%   \paragraph{default.}
+%    \begin{macrocode}
+\if\EqualOption{cover}{lang}{cn}
+  \defbeamertemplate*{logo}{default}{\resizebox{!}{0.7cm}{\cnlogo}}
+\else
+  \defbeamertemplate*{logo}{default}{\resizebox{!}{0.7cm}{\enlogo}}
+\fi
+%    \end{macrocode}
+%
+%    \subsubsection{Title Graphic}
+%    \paragraph{max.}
+%
+%
 %   \subsubsection{Title Page}
 %  
 %   \paragraph{maxplus.}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/02/16 cover library for sjtubeamer v2.5.1]
+\ProvidesPackage{sjtucover}[2022/02/18 cover library for sjtubeamer v2.5.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -54,7 +54,6 @@
   \vfill
   \begingroup
   \usebeamercolor{palette primary}% 
-  \def\sjtubeamer@logocolor{palette primary.fg}
   \begin{tikzpicture}[overlay,
       xshift=-0.12\paperwidth,
       yshift=-0.53\paperheight]
@@ -80,7 +79,8 @@
         {\usebeamercolor[fg]{date}\small\insertdate}%
     };
     \node[anchor=south east, inner sep=0, outer sep=0] at (\outslant,0.5){
-      \resizebox{!}{1cm}{\insertlogo}
+      \usebeamercolor[fg]{palatte primary}
+      \resizebox{!}{1cm}{\usebeamertemplate{logo}}
     };
   \end{tikzpicture}
   \endgroup
@@ -97,11 +97,10 @@
   \nointerlineskip
   \vbox{}
   \usebeamercolor{palette primary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
     rectangle (1*\the\paperwidth, 0.3*\the\paperheight);
-    \node [inner sep=0pt]
+    \node [palette primary.fg, inner sep=0pt]
     at (0.45\paperwidth-6pt,-0.4*\the\paperheight)
     {\resizebox{1.3\paperwidth}{!}{\inserttitlegraphic}};
   \end{tikzpicture}
@@ -163,7 +162,6 @@
 %   Use TikZ rectangle also avoids the unexpected shift because the risk of redefining the internal command is avoided. If there is any text before the title page, the \verb"\maketitle" will start from a new page.
 %    \begin{macrocode}
   \usebeamercolor{palette primary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
     rectangle (1*\the\paperwidth, 0.2*\the\paperheight);
@@ -201,11 +199,10 @@
 %   The institute is in \TeX{} code for typesetting. \verb"\beamer@shortinstitute" meta is used to avoid compressing on \verb"\par", while \verb"\insertinstitute" will force the input to spread on one signle line. The mode to use is depended on the \verb"language" option. Super small font could be made by \verb"fontsize".
 %   Here, we use the option from inner to get the language setting, if this package is used independently, only chinese mode is available.
 %    \begin{macrocode}
-  \usebeamercolor{titlelike}
-  \begin{beamercolorbox}{logo}
+  \begin{beamercolorbox}{palette primary}
     \vskip8pt
     \hbox{
-      \hskip-4pt{\resizebox{!}{1cm}{\insertlogo}}
+      \hskip-4pt{\resizebox{!}{1cm}{\usebeamertemplate{logo}}}
       \ifx\insertinstitute\@empty%
       \else
       \ifx\insertlogo\@empty%
@@ -297,10 +294,6 @@
   % and in the main.tex:
   %    \usetheme[my]{sjtubeamer}\usepackage{mycover}
   %
-  % Remember the change on logo color is temporary,
-  % which will be restored after rendering this page.
-  \usebeamercolor{palette primary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
 }
 %</my>
 %    \end{macrocode}
@@ -338,7 +331,6 @@
   \vfill
   \begin{beamercolorbox}[sep=0pt]{empty}
     \usebeamercolor{structure}
-    \def\sjtubeamer@logocolor{white}
     \begin{tikzpicture}[overlay,xshift=0.54\paperwidth,yshift=-0.41\paperheight]
       \begin{scope}
         \clip (-0.66\paperwidth,0.06\paperheight)
@@ -348,8 +340,8 @@
         \fill[structure.fg!50!black,path fading=fade right img]
         (-0.66\paperwidth,0.06\paperheight)
         rectangle (0.43\paperwidth,0.53\paperheight);
-        \node at (-0.45\paperwidth,0.3\paperheight)
-        {\resizebox{!}{0.115\paperheight}{\insertlogo}};
+        \node[white] at (-0.45\paperwidth,0.3\paperheight)
+        {\resizebox{!}{0.115\paperheight}{\usebeamertemplate{logo}}};
         \draw[white] (-0.66\paperwidth,0.1\paperheight)
         -- (0.43\paperwidth,0.1\paperheight);
       \end{scope}
@@ -391,12 +383,10 @@
       -- (\rightw,-0.59\paperheight)
       -- (\rightw,-0.53\paperheight)
       -- (\midw,-0.68\paperheight) -- cycle;
-      \node at (\midw,-0.65\paperheight) {
-        \def\sjtubeamer@logocolor{black}
+      \node[black] at (\midw,-0.65\paperheight) {
         \resizebox{1.25\paperwidth}{!}{\inserttitlegraphic}};
       \node at (\midw,-0.2\paperheight) {
-        \def\sjtubeamer@logocolor{palette primary.bg}
-        \resizebox{3cm}{!}{\insertlogo}};
+        \resizebox{3cm}{!}{\usebeamertemplate{logo}}};
       \node at (\midw,-0.45\paperheight) {
         \usebeamercolor[bg]{palette primary}
         \LARGE \bfseries\bottomthanks};
@@ -420,7 +410,6 @@
 %    \begin{macrocode}
   \usebeamercolor{palette primary}
   \usebeamercolor{palette secondary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
   \begin{tikzpicture}[overlay,yshift=-80pt]
     \def\w{\the\paperwidth}%
     \def\h{\the\paperheight}%
@@ -442,16 +431,16 @@
 %   Insert the logo in the crossing center of the overlapping circles.
 %    \begin{macrocode}
   \vfill
+  \usebeamercolor[fg]{palette primary}
   \begingroup
   \raggedleft
-  \resizebox{!}{1cm}{\insertlogo}
+  \resizebox{!}{1cm}{\usebeamertemplate{logo}}
 %    \end{macrocode}
 %   Inset the ``thank you'' quote and the title of this beamer. Notice that three \verb"\vfill" divide the frame into three portions with final adjust using \verb"\vskip".
 %    \begin{macrocode}
   \vfill
   \vskip6em
   \begin{beamercolorbox}[sep=8pt]{title}
-    \usebeamercolor[fg]{palette primary}
     \usebeamerfont{title}\noindent\bottomthanks
     \vskip1em%
     \usebeamerfont{subtitle}
@@ -484,10 +473,6 @@
   % and in the main.tex:
   %    \usetheme[my]{sjtubeamer}\usepackage{mycover}
   %
-  % Remember the change on logo color is temporary,
-  % which will be restored after rendering this page.
-  \usebeamercolor{palette primary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
 }
 %</my>
 %    \end{macrocode}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -109,8 +109,8 @@
       yshift=-0.53\paperheight]
     \pgfmathsetlengthmacro{\outslant}{1.02\paperwidth}
     \node[inner sep=0, outer sep=0]
-    at (0.57\paperwidth,0.5\paperheight){
-      \resizebox{!}{1.06\paperheight}{\inserttitlegraphic}};
+      at (0.57\paperwidth,0.5\paperheight){
+        \resizebox{!}{1.06\paperheight}{\vphantom{-}\inserttitlegraphic}};
     \fill[color=white] (0,0) rectangle(1.1\paperwidth,3.9);
     \fill[color=bg]  (0,-0.1\paperheight) rectangle(1.1\paperwidth,3.88);
     \node[anchor=north west, text width=.8\paperwidth]
@@ -130,7 +130,7 @@
     };
     \node[anchor=south east, inner sep=0, outer sep=0] at (\outslant,0.5){
       \usebeamercolor[fg]{palatte primary}
-      \resizebox{!}{1cm}{\usebeamertemplate{logo}}
+      \resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}
     };
   \end{tikzpicture}
   \endgroup
@@ -251,7 +251,7 @@
   \begin{beamercolorbox}{palette primary}
     \vskip8pt
     \hbox{
-      \hskip-4pt{\resizebox{!}{1cm}{\usebeamertemplate{logo}}}
+      \hskip-4pt{\resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}}
       \ifx\insertinstitute\@empty%
       \else
       \ifx\insertlogo\@empty%
@@ -390,7 +390,7 @@
         (-0.66\paperwidth,0.06\paperheight)
         rectangle (0.43\paperwidth,0.53\paperheight);
         \node[white] at (-0.45\paperwidth,0.3\paperheight)
-        {\resizebox{!}{0.115\paperheight}{\usebeamertemplate{logo}}};
+        {\resizebox{!}{0.115\paperheight}{\vphantom{-}\usebeamertemplate{logo}}};
         \draw[white] (-0.66\paperwidth,0.1\paperheight)
         -- (0.43\paperwidth,0.1\paperheight);
       \end{scope}
@@ -435,7 +435,7 @@
       \node[black] at (\midw,-0.65\paperheight) {
         \resizebox{1.25\paperwidth}{!}{\inserttitlegraphic}};
       \node at (\midw,-0.2\paperheight) {
-        \resizebox{3cm}{!}{\usebeamertemplate{logo}}};
+        \resizebox{3cm}{!}{\hphantom{-}\usebeamertemplate{logo}}};
       \node at (\midw,-0.45\paperheight) {
         \usebeamercolor[bg]{palette primary}
         \LARGE \bfseries\bottomthanks};
@@ -483,7 +483,7 @@
   \usebeamercolor[fg]{palette primary}
   \begingroup
   \raggedleft
-  \resizebox{!}{1cm}{\usebeamertemplate{logo}}
+  \resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}
 %    \end{macrocode}
 %   Inset the ``thank you'' quote and the title of this beamer. Notice that three \verb"\vfill" divide the frame into three portions with final adjust using \verb"\vskip".
 %    \begin{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/02/16 Visual Identity System library for sjtubeamer v2.5.1]
+\ProvidesPackage{sjtuvi}[2022/02/18 Visual Identity System library for sjtubeamer v2.5.2]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -133,13 +133,13 @@
       \node {\includegraphics[height=1.5cm]{#1/#2}};
     \end{tikzfadingfrompicture}
   \fi
-  \expandafter\providecommand\csname #2\endcsname[1][\sjtubeamer@logocolor]{
+  \expandafter\providecommand\csname #2\endcsname[1][]{
     % ##1: override color, or opacity=... (optional)
     \tikzexternaldisable
     \begin{tikzpicture}
       \begin{scope}
         \clip ({-1.0+#3},{-1.0+#4}) rectangle ({1.0-#3},{1.0-#4});
-        \fill [\sjtubeamer@logocolor, ##1, path fading=#2]
+        \fill [##1, path fading=#2]
           (-1,-1) rectangle (1,1);
       \end{scope}
     \end{tikzpicture}
@@ -148,10 +148,6 @@
 %    \end{macrocode}
 % \end{macro}
 %
-%   WARNING: This library will define the initial color to sjtuRedPrimary, remember to change the variable after using this package!
-%    \begin{macrocode}
-\def\sjtubeamer@logocolor{sjtuRedPrimary}
-%    \end{macrocode}
 %    Define the required logo.
 %    \begin{macrocode}
 \definelogo{sjtubadge}{0}{0}

--- a/src/support/tutorial/my.sty
+++ b/src/support/tutorial/my.sty
@@ -6,7 +6,7 @@
 \definelogo{sjtugtext}{0}{0}
 \setbeamertemplate{background}{
     \bgcenterbox{
-        \sjtugtext[opacity=0.15]
+        \sjtugtext[cprimary,opacity=0.15]
     }
 }
 \defbeamertemplatealias{title page}{my}{maxplus}


### PR DESCRIPTION
本 PR 重构了 Logo Color System，删去了全局变量 `\sjtubeamer@logocolor`，改为 logo 随着文本颜色的变化而变化。

- 对于创建出来的徽标原语，仍然可以使用可选参数更改徽标颜色，`\cnlogo[cprimary]`。
- 对于 `\insertlogo` 而言，会调用 `\usebeamertemplate*{logo}` 而采用 color theme 里的 logo.fg 控制默认颜色。
- 想要更改 `\insertlogo` （不接受参数）的颜色，需要改用 `\usebeamertemplate{logo}`，并在此之前修改文本颜色。

本 PR 也重载了 `beamer` 中的 `\titlegraphic` 定义，改为使用 beamer template，下沉了 logo 和 titlegraphic 到 cover 中以统一管理这些模板。

修改了插件里的一处徽标插入，添加了颜色参数。将会在下面的 PR 中逐步完成插件的范例完善，这个 PR 就不再检查该插件。