### PR TITLE
feat: default dark, sidebar logo and infolines color

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ SJTUBeamer 是上海交通大学的非官方 Beamer 模版。您可以使用 SJT
 %   miniframes infolines  sidebar* 
 %   default    smoothbars split	 
 %   shadow     tree       smoothtree
-% *siderbar 推荐与 max 一起使用。
 
 % \tikzexternalize[prefix=build/]
 % 如果您需要缓存 tikz 图像，请取消注释上一行，并在编译选项中添加 -shell-escape。

--- a/README_en.md
+++ b/README_en.md
@@ -27,7 +27,6 @@ Current document `main.tex` is an example documentation of *How to Use LaTeX to 
 %   miniframes infolines  sidebar*
 %   default    smoothbars split	 
 %   shadow     tree       smoothtree
-% *siderbar is recommended to be used with max option.
 
 % \tikzexternalize[prefix=build/]
 % To cache the tikz picture, please uncomment the previous line.

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/18 sjtubeamer color theme v2.5.2]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/18 sjtubeamer color theme v2.5.3]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/18 sjtubeamer font theme v2.5.2]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/18 sjtubeamer font theme v2.5.3]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/18 sjtubeamer inner theme v2.5.2]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/18 sjtubeamer inner theme v2.5.3]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/18 sjtubeamer outer theme v2.5.2]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/18 sjtubeamer outer theme v2.5.3]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}
@@ -83,6 +83,8 @@
   \useoutertheme[footline=institutetitle]{miniframes}
 \else\if\EqualOption{outer}{nav}{sidebar}
     \useoutertheme{sidebar}
+    \logo{\resizebox{!}{1cm}{\sjtubadge}}
+    \def\sjtubeamer@outer@logopos{topright}
     \AtBeginDocument{
       \setbeamertemplate{frametitle}[sidebar theme]
     }
@@ -90,8 +92,20 @@
     \useoutertheme{\sjtubeamer@outer@nav}
     \setbeamercolor{title in head/foot}{use=structure,bg=white,fg=structure.fg}
   \fi\fi
-\setbeamercolor{frametitle}{use=titlelike,bg=white,fg=titlelike.fg}
-\setbeamercolor{frametitle right}{parent=subsection in head/foot}
+\if\EqualOption{outer}{nav}{default}
+  \setbeamercolor{frametitle}{use=palette primary,
+    bg=palette primary.bg,fg=palette primary.fg}
+\else\if\EqualOption{outer}{nav}{infolines}
+  \setbeamercolor{author in head/foot}{use=structure,fg=white,bg=structure}
+  \setbeamercolor{title in head/foot}{use=structure,fg=structure,bg=structure!10}
+  \setbeamercolor{date in head/foot}{use=structure,fg=structure,bg=structure!20}
+  \setbeamercolor{section in head/foot}{parent=author in head/foot}
+  \setbeamercolor{subsection in head/foot}{parent=date in head/foot}
+  \setbeamersize{text margin left=1cm,text margin right=1cm}
+\else
+  \setbeamercolor{frametitle}{use=titlelike,bg=white,fg=titlelike.fg}
+  \setbeamercolor{frametitle right}{parent=subsection in head/foot}
+\fi\fi
 \setbeamertemplate{sidebar right}{}
 \addtobeamertemplate{navigation symbols}{}{
   \hbox{

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/02/18 sjtubeamer parent theme v2.5.2]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/02/18 sjtubeamer parent theme v2.5.3]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/main.tex
+++ b/main.tex
@@ -113,7 +113,6 @@
 %   miniframes infolines  sidebar* 
 %   default    smoothbars split	 
 %   shadow     tree       smoothtree
-% *siderbar 推荐与 max 一起使用。
 
 % \tikzexternalize[prefix=build/]
 % 如果您需要缓存 tikz 图像，请取消注释上一行，并在编译选项中添加 -shell-escape。

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/02/18 cover library for sjtubeamer v2.5.2]
+\ProvidesPackage{sjtucover}[2022/02/18 cover library for sjtubeamer v2.5.3]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{cn}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/02/18 Visual Identity System library for sjtubeamer v2.5.2]
+\ProvidesPackage{sjtuvi}[2022/02/18 Visual Identity System library for sjtubeamer v2.5.3]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/18 sjtubeamer color theme v2.5.2]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/18 sjtubeamer color theme v2.5.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/18 sjtubeamer font theme v2.5.2]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/18 sjtubeamer font theme v2.5.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/18 sjtubeamer inner theme v2.5.2]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/18 sjtubeamer inner theme v2.5.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -170,11 +170,15 @@
   \setbeamercolor{date in head/foot}{use=structure,fg=structure,bg=structure!20}
   \setbeamercolor{section in head/foot}{parent=author in head/foot}
   \setbeamercolor{subsection in head/foot}{parent=date in head/foot}
-\else
+%    \end{macrocode}
+% And \verb"infolines" also resize the text margin, we reset the margin to the default size in order to avoid unwanted shift in covers.
+%    \begin{macrocode}
+  \setbeamersize{text margin left=1cm,text margin right=1cm}
 %    \end{macrocode}
 %   Color patch for sidebar, shadow, and smoothtrees.
 %   WARNING: This cannot be moved to the color theme, since the color was set in the outer theme itself. And the outer theme is the last theme to be loaded.
 %    \begin{macrocode}
+\else
   \setbeamercolor{frametitle}{use=titlelike,bg=white,fg=titlelike.fg}
   \setbeamercolor{frametitle right}{parent=subsection in head/foot}
 \fi\fi

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -73,7 +73,7 @@
 %
 %   Define the beamer template \verb"frametitle" to add a logo in the right of the frametitle (top right corner) for \verb"topright" option. If it is not \verb"topright" option, then the default \verb"frametitle" template is used.
 %
-%   \verb"smoothbars", \verb"smoothtree" and \verb"shadow" theme use a different frame title insertion mechanism so that the redefinition on \verb"frametitle" should be done just after the document starts. This overwrites the original definition of those outer theme and may cause a certain degree of style lost.
+%   \verb"smoothbars", \verb"smoothtree" and \verb"shadow" theme use a different frame title insertion mechanism in \verb"beamer" class so that the redefinition on \verb"frametitle" should be done just after the document starts. This overwrites the original definition of those outer theme and may cause a certain degree of style lost.
 %    \begin{macrocode}
 \if\EqualOption{outer}{logopos}{topright}
   \AtBeginDocument{
@@ -128,17 +128,26 @@
 \if\EqualOption{outer}{nav}{miniframes}
   \useoutertheme[footline=institutetitle]{miniframes}
 %    \end{macrocode}
-% Sidebar. Use the default template for \verb"frametitle" in sidebar, since there has already been a logo in the top left corner.
-% And it will use the logo position configuration \verb"topright" for sidebar to remove the logo in the bottom right corner.
+% Sidebar.
 %    \begin{macrocode}
 \else\if\EqualOption{outer}{nav}{sidebar}
     \useoutertheme{sidebar}
+%    \end{macrocode}
+% Since the logo area in the sidebar theme is square, so the default configuration for \verb"\logo" will be \verb"\sjtubadge" no matter what kind of cover processed in the inner theme. If you want to modify the logo later, change the logo manually after loading the theme.
+%    \begin{macrocode}
+    \logo{\resizebox{!}{1cm}{\sjtubadge}}
+%    \end{macrocode}
+% And it will use the logo position configuration \verb"topright" for sidebar to remove the logo in the bottom right corner. The config could not be modified after the outer theme is loaded.
+%    \begin{macrocode}
     \def\sjtubeamer@outer@logopos{topright}
+%    \end{macrocode}
+% Use the default template for \verb"frametitle" in sidebar, since there has already been a logo in the top left corner. The setup has to be after document starts since the previous set of \verb"frametitle" template is also set up after document as is shown above. Appending on this hook will override the previous setup.
+%    \begin{macrocode}
     \AtBeginDocument{
       \setbeamertemplate{frametitle}[sidebar theme]
     }
 %    \end{macrocode}
-% If it is other theme, change the beamercolor to fit smooth* theme.
+% If it is the other theme, change the beamercolor to fit smooth* theme.
 %    \begin{macrocode}
   \else
     \useoutertheme{\sjtubeamer@outer@nav}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -160,6 +160,16 @@
 \if\EqualOption{outer}{nav}{default}
   \setbeamercolor{frametitle}{use=palette primary,
     bg=palette primary.bg,fg=palette primary.fg}
+%    \end{macrocode}
+% Since \verb"infolines" outer theme in \verb"beamer" class has redefined the beamer color below which doesn't confirm the standing-free principle, the redefined color will override after the outer theme is loaded. 
+% \verb"structure" beamer color stores the \verb"cprimary". Set the color relative to this for decoupling reasons.
+%    \begin{macrocode}
+\else\if\EqualOption{outer}{nav}{infolines}
+  \setbeamercolor{author in head/foot}{use=structure,fg=white,bg=structure}
+  \setbeamercolor{title in head/foot}{use=structure,fg=structure,bg=structure!10}
+  \setbeamercolor{date in head/foot}{use=structure,fg=structure,bg=structure!20}
+  \setbeamercolor{section in head/foot}{parent=author in head/foot}
+  \setbeamercolor{subsection in head/foot}{parent=date in head/foot}
 \else
 %    \end{macrocode}
 %   Color patch for sidebar, shadow, and smoothtrees.
@@ -167,7 +177,7 @@
 %    \begin{macrocode}
   \setbeamercolor{frametitle}{use=titlelike,bg=white,fg=titlelike.fg}
   \setbeamercolor{frametitle right}{parent=subsection in head/foot}
-\fi
+\fi\fi
 %    \end{macrocode}
 %
 % \subsubsection{Bottombar}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -129,9 +129,11 @@
   \useoutertheme[footline=institutetitle]{miniframes}
 %    \end{macrocode}
 % Sidebar. Use the default template for \verb"frametitle" in sidebar, since there has already been a logo in the top left corner.
+% And it will use the logo position configuration \verb"topright" for sidebar to remove the logo in the bottom right corner.
 %    \begin{macrocode}
 \else\if\EqualOption{outer}{nav}{sidebar}
     \useoutertheme{sidebar}
+    \def\sjtubeamer@outer@logopos{topright}
     \AtBeginDocument{
       \setbeamertemplate{frametitle}[sidebar theme]
     }

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/18 sjtubeamer outer theme v2.5.2]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/18 sjtubeamer outer theme v2.5.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -144,11 +144,19 @@
   \fi\fi
 %    \end{macrocode}
 %
+%   Color patch for default outer theme.
+%    \begin{macrocode}
+\if\EqualOption{outer}{nav}{default}
+  \setbeamercolor{frametitle}{use=palette primary,
+    bg=palette primary.bg,fg=palette primary.fg}
+\else
+%    \end{macrocode}
 %   Color patch for sidebar, shadow, and smoothtrees.
 %   WARNING: This cannot be moved to the color theme, since the color was set in the outer theme itself. And the outer theme is the last theme to be loaded.
 %    \begin{macrocode}
-\setbeamercolor{frametitle}{use=titlelike,bg=white,fg=titlelike.fg}
-\setbeamercolor{frametitle right}{parent=subsection in head/foot}
+  \setbeamercolor{frametitle}{use=titlelike,bg=white,fg=titlelike.fg}
+  \setbeamercolor{frametitle right}{parent=subsection in head/foot}
+\fi
 %    \end{macrocode}
 %
 % \subsubsection{Bottombar}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -68,7 +68,7 @@
 \beamer@compresstrue
 %    \end{macrocode}
 %
-% \subsubsection{Frame Title}
+% \subsubsection{Frame Title}\label{sec:frametitle}
 %
 %
 %   Define the beamer template \verb"frametitle" to add a logo in the right of the frametitle (top right corner) for \verb"topright" option. If it is not \verb"topright" option, then the default \verb"frametitle" template is used.
@@ -133,15 +133,15 @@
 \else\if\EqualOption{outer}{nav}{sidebar}
     \useoutertheme{sidebar}
 %    \end{macrocode}
-% Since the logo area in the sidebar theme is square, so the default configuration for \verb"\logo" will be \verb"\sjtubadge" no matter what kind of cover processed in the inner theme. If you want to modify the logo later, change the logo manually after loading the theme.
+% Since the logo area in the sidebar theme is square, the default configuration for \verb"\logo" will be \verb"\sjtubadge" no matter what kind of cover processed in the inner theme. If you want to modify the logo later, change the logo manually after loading the theme.
 %    \begin{macrocode}
     \logo{\resizebox{!}{1cm}{\sjtubadge}}
 %    \end{macrocode}
-% And it will use the logo position configuration \verb"topright" for sidebar to remove the logo in the bottom right corner. The config could not be modified after the outer theme is loaded.
+% And it will use the logo position configuration \verb"topright" for sidebar to remove the logo in the bottom right corner. The config will not be modified after the outer theme is loaded.
 %    \begin{macrocode}
     \def\sjtubeamer@outer@logopos{topright}
 %    \end{macrocode}
-% Use the default template for \verb"frametitle" in sidebar, since there has already been a logo in the top left corner. The setup has to be after document starts since the previous set of \verb"frametitle" template is also set up after document as is shown above. Appending on this hook will override the previous setup.
+% Use the default template for \verb"frametitle" in sidebar, since there has already been a logo in the top left corner. The setup has to be done after document starts since the previous set of \verb"frametitle" template is also set up after document as is shown in Section \ref{sec:frametitle}. Appending on this hook will override the previous setup.
 %    \begin{macrocode}
     \AtBeginDocument{
       \setbeamertemplate{frametitle}[sidebar theme]

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/02/18 sjtubeamer parent theme v2.5.2]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/02/18 sjtubeamer parent theme v2.5.3]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/02/18 cover library for sjtubeamer v2.5.2]
+\ProvidesPackage{sjtucover}[2022/02/18 cover library for sjtubeamer v2.5.3]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/02/18 Visual Identity System library for sjtubeamer v2.5.2]
+\ProvidesPackage{sjtuvi}[2022/02/18 Visual Identity System library for sjtubeamer v2.5.3]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
本 PR 稍微修改了一些外样式对应的外观：
- `default` 在 dark 模式下，页标题会变为深色背景。
- `sidebar` 修复了一个右下角会重复出现的问题，并且不论加载了何种主题都会默认logo为方形，之后用户可以进行再次调整。
- `infolines` 重新调整了边栏的颜色更类似于 `Cambridge` 主题，修复了 `beamer` 加载该主题导致的两侧边距减少的问题。

<img width="437" alt="image" src="https://user-images.githubusercontent.com/61653082/154702294-cef57999-427c-4150-84f5-94ce739bc97b.png">

TODO: `sidebar` 的 plain 模式页面仍然会有一定的左侧文本间距变大问题，是因为 `beamer` 在该主题上的处理不同所致，需要手动处理这种情况（或者不处理，现在看着可能还行，之前就放着来着 #29）

<img width="347" alt="image" src="https://user-images.githubusercontent.com/61653082/154702584-93ccdc47-9969-4290-a9f0-35fe731f9542.png">
