### PR TITLE
refactor: highlighters

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -50,14 +50,14 @@
 	"highlight": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\highlight",
-		"body": "\\highlight[${1:cprimary}]{$2}",
-		"description": "Highlight the given text. Create a primary color background block with white as foreground.\n"
+		"body": "\\highlight[${1:structure}]{$2}",
+		"description": "Highlight the given text. Create a structure color background block with white text.\nReceives one optional paramenter to specify the background color. If you want to modify the color of the text, use \\color{} command or \\textcolor{}{} command for your text.\nFor a general use and better control, use \\colorbox{}{} from xcolor directly.\n"
 	},
 	"paragraph": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\paragraph",
 		"body": "\\paragraph{$1}",
-		"description": "Use \\highlight macro for making contrast.\nSince beamer has deleted \\paragraph macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from article class.\n"
+		"description": "Making a new paragraph through dark background color and white forground, which confirms the visual identity system on making use of vi shapes.\nSince beamer has deleted \\paragraph macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from article class.\nIf it is the end of paragraph, the trailing space will be removed by \\TeX{}. The additional newline after this command will be get an output rather than the original sectioning command.\n"
 	},
 	"stampbox": {
 		"scope": "doctex,tex,latex",
@@ -70,6 +70,12 @@
 		"prefix": "\n\\begin{codeblock",
 		"body": "\n\\begin{codeblock}[${1:}]{$2}\n\t$3\n\\end{codeblock}\n",
 		"description": "Code block environment is made for presenting code in an obvious way. Two parameters are required. The first parameter is passed to listing, which mostly sets the language to highlight, see the listings package for more details. And the second parameter receives the title to make.\n"
+	},
+	"highlightline": {
+		"scope": "doctex,tex,latex",
+		"prefix": "\\highlightline",
+		"body": "\\highlightline",
+		"description": "Highlight the current line with a light background. \nIt is useful for the codeblock environment with escapechar option to insert the command for highlighting. For example, set the optional argument escapechar=|, and insert |\\highlightline| at the first position in the line you want to highlight.\n"
 	},
 	"sjtubeamer@outer@nav": {
 		"scope": "doctex,tex",
@@ -184,6 +190,18 @@
 		"prefix": "\\sjtubeamer@compatible",
 		"body": "\\sjtubeamer@compatible",
 		"description": ""
+	},
+	"getheightofnode": {
+		"scope": "doctex,tex",
+		"prefix": "\\getheightofnode",
+		"body": "\\getheightofnode{$1}{$2}",
+		"description": "A helper macro to get the height of a tikz node \\#2 and store it in length \\#1. You have to declare the length \\#1 first by using \\newlength.\n"
+	},
+	"stamptext": {
+		"scope": "doctex,tex,latex",
+		"prefix": "\\stamptext",
+		"body": "\\stamptext[${1:structure}]{$2}",
+		"description": "Make a stamp unit surround the text. Similar to \\highlight command in inner theme with limitations on number of characters.\nUse one Chinese character or at most two English characters for the argument.\nUse an optional argument to set the background color, default is structure. Avoid using this macro if you are not in beamer class, or use a defined color for background.\n"
 	},
 	"stamp": {
 		"scope": "doctex,tex,latex",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -185,23 +185,17 @@
 		"body": "\\definelogo[${1:vi}]{$2}{$3}{$4}",
 		"description": "Define a mask picture to make its different color variants.\nThe first argument assigns the file name and the second sets the horizontal cropping and the third sets the vertical cropping. Notice that the cropping is symmetrical (double the length). When the horizontal cropping is greater than the vertical cropping, the mask will be placed by its height, otherwise by its width. The domain for both cropping parameters is 0 to 1.\nYou should define a logo \\definelogo{mylogo}{<hc>}{<vc>} then use it in the contents like:\n\\mylogo[white], where the optional parameter could be the override color beyond the control of main logo color system or opacity=... to identify the opacity you want or any other parameter for a TikZ node.\nRemember, the picture should be in the vi/ folder by default. If you want to use some other file in other folder, add an optional paramter like \\definelogo[folder]{file}{0}{0} will get the folder/file.\nThe externalization will be disabled when using this system to generate logos, locally.\n"
 	},
+	"stamptext": {
+		"scope": "doctex,tex,latex",
+		"prefix": "\\stamptext",
+		"body": "\\stamptext[${1:structure}]{$2}",
+		"description": "Use one Chinese character or at most two English characters for the text argument.\nMake a stamp unit surround the text. Similar to \\highlight command in inner theme with limitations on number of characters.\nUse an optional argument to set the background color, default is structure. Avoid using this macro if you are not in beamer class, or use a defined color for background.\n"
+	},
 	"sjtubeamer@compatible": {
 		"scope": "doctex,tex",
 		"prefix": "\\sjtubeamer@compatible",
 		"body": "\\sjtubeamer@compatible",
 		"description": ""
-	},
-	"getheightofnode": {
-		"scope": "doctex,tex",
-		"prefix": "\\getheightofnode",
-		"body": "\\getheightofnode{$1}{$2}",
-		"description": "A helper macro to get the height of a tikz node \\#2 and store it in length \\#1. You have to declare the length \\#1 first by using \\newlength.\n"
-	},
-	"stamptext": {
-		"scope": "doctex,tex,latex",
-		"prefix": "\\stamptext",
-		"body": "\\stamptext[${1:structure}]{$2}",
-		"description": "Make a stamp unit surround the text. Similar to \\highlight command in inner theme with limitations on number of characters.\nUse one Chinese character or at most two English characters for the argument.\nUse an optional argument to set the background color, default is structure. Avoid using this macro if you are not in beamer class, or use a defined color for background.\n"
 	},
 	"stamp": {
 		"scope": "doctex,tex,latex",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -189,7 +189,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\\stamptext",
 		"body": "\\stamptext[${1:structure}]{$2}",
-		"description": "Use one Chinese character or at most two English characters for the text argument.\nMake a stamp unit surround the text. Similar to \\highlight command in inner theme with limitations on number of characters.\nUse an optional argument to set the background color, default is structure. Avoid using this macro if you are not in beamer class, or use a defined color for background.\n"
+		"description": "Use one Chinese character or at most two English characters for the text argument.\nMake a stamp unit surround the text. Similar to \\highlight command in inner theme with limitations on number of characters.\nUse an optional argument to set the background color, default is structure or sjtuRedPrimary.\n"
 	},
 	"sjtubeamer@compatible": {
 		"scope": "doctex,tex",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/19 sjtubeamer color theme v2.5.3]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/24 sjtubeamer color theme v2.5.4]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/19 sjtubeamer font theme v2.5.3]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/24 sjtubeamer font theme v2.5.4]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -122,21 +122,8 @@
 \if\EqualOption{inner}{cover}{min}\else
   \setbeamertemplate{blocks}[rounded]
 \fi
-\newtcbox{\highlight}[1][cprimary]{
-  on line,
-  arc=0pt,
-  colback=#1,
-  colupper=white,
-  boxrule=0pt,
-  boxsep=0pt,
-  left=4pt,
-  right=4pt,
-  top=2pt,
-  bottom=2pt
-}
-\providecommand{\paragraph}[1]{
-  \highlight{#1}~
-}
+\newcommand{\highlight}[2][structure]{\textcolor{white}{\colorbox{#1}{#2}}}
+\providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\hspace{0.5em}}
 \newtcolorbox{stampbox}[1][cprimary]{%
   capture=hbox,
   enhanced,
@@ -179,15 +166,17 @@
   sharp corners,
   top=0mm,
   bottom=0mm,
+  right*=0.5mm,
   title=#2,
   colback=cprimary!5,
   colframe=cprimary!80,
   overlay={
     \begin{tcbclipinterior}\fill[cprimary!20]%
-      (frame.south west) rectangle ([xshift=5mm]frame.north west);
+      (frame.south west) rectangle ([xshift=5.5mm]frame.north west);
     \end{tcbclipinterior}
   }
 }
+\providecommand{\highlightline}{\rlap{\color{ctertiary!40}\rule[-\dp\strutbox]{\linewidth}{\baselineskip}}}
 \AtEndPreamble{%
   \@ifpackageloaded{pgfplots}{%
     \pgfplotsset{

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -123,7 +123,7 @@
   \setbeamertemplate{blocks}[rounded]
 \fi
 \newcommand{\highlight}[2][structure]{\textcolor{white}{\colorbox{#1}{#2}}}
-\providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\hspace{0.5em}}
+\providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\space}
 \newtcolorbox{stampbox}[1][cprimary]{%
   capture=hbox,
   enhanced,

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/19 sjtubeamer inner theme v2.5.3]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/24 sjtubeamer inner theme v2.5.4]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/19 sjtubeamer outer theme v2.5.3]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/24 sjtubeamer outer theme v2.5.4]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/02/19 sjtubeamer parent theme v2.5.3]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/02/24 sjtubeamer parent theme v2.5.4]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/02/19 cover library for sjtubeamer v2.5.3]
+\ProvidesPackage{sjtucover}[2022/02/24 cover library for sjtubeamer v2.5.4]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{cn}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/02/19 Visual Identity System library for sjtubeamer v2.5.3]
+\ProvidesPackage{sjtuvi}[2022/02/24 Visual Identity System library for sjtubeamer v2.5.4]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key
@@ -84,19 +84,15 @@
 \definelogo{dlogo}{0}{0}
 \definelogo{vlogo}{0.8}{0.13}
 \definelogo{sjtubg}{0.3}{0.5}
-\def\sjtubeamer@compatible@false{false}
-\def\getheightofnode#1#2{%
-  \pgfextracty{#1}{\pgfpointanchor{#2}{north}}%
-  \pgfextracty{\pgf@ya}{\pgfpointanchor{#2}{south}}%
-  \addtolength{#1}{-\pgf@ya}
-}
 \providecommand{\stamptext}[2][structure]{
   {
     \tikzset{external/export=false}
     \begin{tikzpicture}[baseline=(nodetext.base)]
       \node [white] (nodetext) at (0,0) {#2};
       \newlength{\s}
-      \getheightofnode{\s}{nodetext}
+      \pgfextracty{\s}{\pgfpointanchor{nodetext}{north}}%
+      \pgfextracty{\pgf@ya}{\pgfpointanchor{nodetext}{south}}%
+      \addtolength{\s}{-\pgf@ya}
       \scoped[on background layer]
         \fill [#1]
           (-1.25*\s,0)
@@ -112,6 +108,7 @@
     \end{tikzpicture}
   }
 }
+\def\sjtubeamer@compatible@false{false}
 \ifx\sjtubeamer@compatible\sjtubeamer@compatible@false
 \else
   \usetikzlibrary{patterns.meta}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -86,6 +86,7 @@
 \definelogo{sjtubg}{0.3}{0.5}
 \providecommand{\stamptext}[2][structure]{
   {
+    \providecolor{#1}{named}{sjtuRedPrimary}
     \tikzset{external/export=false}
     \begin{tikzpicture}[baseline=(nodetext.base)]
       \node [white] (nodetext) at (0,0) {#2};

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -42,6 +42,7 @@
 \usetikzlibrary{fadings}
 \usetikzlibrary{decorations.pathmorphing}
 \usetikzlibrary{external}
+\usetikzlibrary{backgrounds}
 \definecolor{sjtuRedPrimary}{RGB}{167,32,56}         %engred
 \definecolor{sjtuRedSecondary}{RGB}{240,131,0}       %orange
 \definecolor{sjtuRedTertiary}{RGB}{253,208,0}        %yellow
@@ -84,6 +85,33 @@
 \definelogo{vlogo}{0.8}{0.13}
 \definelogo{sjtubg}{0.3}{0.5}
 \def\sjtubeamer@compatible@false{false}
+\def\getheightofnode#1#2{%
+  \pgfextracty{#1}{\pgfpointanchor{#2}{north}}%
+  \pgfextracty{\pgf@ya}{\pgfpointanchor{#2}{south}}%
+  \addtolength{#1}{-\pgf@ya}
+}
+\providecommand{\stamptext}[2][structure]{
+  {
+    \tikzset{external/export=false}
+    \begin{tikzpicture}[baseline=(nodetext.base)]
+      \node [white] (nodetext) at (0,0) {#2};
+      \newlength{\s}
+      \getheightofnode{\s}{nodetext}
+      \scoped[on background layer]
+        \fill [#1]
+          (-1.25*\s,0)
+          -- (-0.85*\s,0.3*\s)
+          -- (-0.85*\s,0.5*\s)
+          -- (0.85*\s,0.5*\s)
+          -- (0.85*\s,0.3*\s)
+          -- (1.25*\s,0)
+          -- (0.85*\s,-0.3*\s)
+          -- (0.85*\s,-0.5*\s)
+          -- (-0.85*\s,-0.5*\s)
+          -- (-0.85*\s,-0.3*\s) -- cycle;
+    \end{tikzpicture}
+  }
+}
 \ifx\sjtubeamer@compatible\sjtubeamer@compatible@false
 \else
   \usetikzlibrary{patterns.meta}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -359,8 +359,7 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[1]{step12.tex}
 
 \begin{commentlist}
-  \item \texttt{block}, \texttt{alertblock}, \texttt{exampleblock} 环境分别可以产生与主题色对应的三种盒子。
-  \item \texttt{min} 主题的盒子非圆角$^*$。
+  \item \texttt{block}, \texttt{alertblock}, \texttt{exampleblock} 环境分别可以产生与主题色对应的三种盒子。\texttt{min} 主题的盒子非圆角$^*$。
   \item \texttt{stampbox} 环境可以产生印记边框盒子$^*$，可以丰富视觉效果与统一视觉形象。可接受一个可选参数如 \texttt{[sjtuBluePrimary]} 产生其他颜色的边框。
 \end{commentlist}
 
@@ -536,9 +535,10 @@ fontupper=\sffamily,colupper=white}
   \centering
   \begin{tabular}{>{\ttfamily}c>{\ttfamily}c>{\ttfamily}c}
     \hline
-    \textbackslash{}makebottom & \textbackslash{}emph      & \textbackslash{}highlight  \\
-    \textbackslash{}paragraph  & codeblock                 & \textbackslash{}stamparray \\
-    \textbackslash{}*logo      & \textbackslash{}sjtubadge & stampbox                   \\
+    \textbackslash{}makebottom & \textbackslash{}emph          & \textbackslash{}highlight  \\
+    \textbackslash{}paragraph  & codeblock                     & \textbackslash{}stamparray \\
+    \textbackslash{}*logo      & \textbackslash{}sjtubadge     & stampbox                   \\
+    \textbackslash{}stamptext  & \textbackslash{}highlightline & \textbackslash{}usemytheme \\
     \hline
   \end{tabular}
 \end{table}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -347,6 +347,7 @@ fontupper=\sffamily,colupper=white}
 \begin{commentlist}
   \item \texttt{\textbackslash{}alert} 会改变文字颜色为主题色。\texttt{\textbackslash{}emph} 会改变文字颜色的同时，还会将英文字体变为斜体$^*$。
   \item \texttt{\textbackslash{}paragraph} 和 \texttt{\textbackslash{}highlight} 都会在文字底部添加纯色方块$^*$，区别在于后者可以设置背景颜色。
+  \item \texttt{\textbackslash{}stamptext} 可以用于生成以印记形为底的高亮小块$^*$，需要将高亮的文字数目控制在一个中文字或两个英文字。
 \end{commentlist}
 
 \section{区块强调}
@@ -370,8 +371,8 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[1]{step13.tex}
 
 \begin{commentlist}
-  \item \texttt{codeblock} 提供了带行号的代码抄录环境$^*$，第一个可选参数可以用于设置语言，第二个必选参数可以设置代码块的标题。
-  \item 需要清理抄录代码在源文件中的缩进，顶格输入。
+  \item \texttt{codeblock} 提供了带行号的代码抄录环境$^*$，第一个可选参数可以用于设置语言与其他抄录选项，第二个必选参数可以设置代码块的标题。
+  \item 需要清理抄录代码在源文件中的缩进，顶格输入。如果想要高亮某一行$^*$，请设置 \verb"escapechar=|" 可选参数后，在该行开头顶格输入 \verb"|\highlightline|"。
   \item 直接使用 \texttt{listings} 宏包提供的 \texttt{lstlisting} 环境依然可行，\themename\ 已经对其进行了一些预先的优化。
   \item[\faExclamationTriangle] 使用代码块的页其 \texttt{frame} 环境必须添加 \texttt{fragile} 参数。
 \end{commentlist}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/19 sjtubeamer color theme v2.5.3]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/02/24 sjtubeamer color theme v2.5.4]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/19 sjtubeamer font theme v2.5.3]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/02/24 sjtubeamer font theme v2.5.4]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -296,20 +296,29 @@
 %    \end{macrocode}
 %
 % \begin{macro}{\highlight}
-%   Highlight the given text. Create a light primary color background block without modifying the text color. This method is more familiar with the usual way on highlighting.
-%   Since \verb"structure" is globally available, we can use it to set the background color without introducing first. Set to 10\% of the structure to make enough contrast even if it is in a block (which is 30\% light).
-%   Receives one optional paramenter to specify the background color. If you want to modify the color it is highlighted, modify the text color manually.
+%   Highlight the given text. Create a \verb"structure" color background block with white text.
+%   Receives one optional paramenter to specify the background color. If you want to modify the color of the text, use \verb"\color{}" command or \verb"\textcolor{}{}" command for your text.
+%   For a general use, use \verb"\colorbox{}{}" from \verb"xcolor" directly.
 %    \begin{macrocode}
-\newcommand{\highlight}[2][structure!10]{\colorbox{#1}{#2}}
+\newcommand{\highlight}[2][structure]{\textcolor{white}{\colorbox{#1}{#2}}}
 %    \end{macrocode}
+%   Since \verb"structure" is globally available, we can use it to set the background color without introducing first.
 % \end{macro}
 %
 % \begin{macro}{\paragraph}
-%   Making contrast through dark background color and white forground, which confirms the visual identity system on making use of vi shapes.
+%   Making a new paragraph through dark background color and white forground, which confirms the visual identity system on making use of vi shapes.
 %   Since beamer has deleted \verb"\paragraph" macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from \verb"article" class.
-%   If it is the end of paragraph, the trailing space will be removed by \TeX{}.
 %    \begin{macrocode}
-\providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\hspace{0.5em}}
+\def\paragraph{
+%    \end{macrocode}
+%   Though we could define \verb"\paragraph" like \verb"\highlight" above, we decided to use the orginal \LaTeX{} definition on \verb"\paragraph".
+%   Because the the internal macro \verb"\@startsection" will remove the following spaces and newlines, which is the behavior of \LaTeX{} paragraph as the sectioning command.
+%    \begin{macrocode}
+  \@startsection{paragraph}{4}{\z@}
+                {3.25ex \@plus1ex \@minus.2ex}
+                {-1em}%
+                {\color{white}\colorbox{structure}}
+}
 %    \end{macrocode}
 % \end{macro}
 %

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/19 sjtubeamer inner theme v2.5.3]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/02/24 sjtubeamer inner theme v2.5.4]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -314,12 +314,13 @@
 \providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\hspace{0.5em}}
 %    \end{macrocode}
 %   NOTE: We could use the original \LaTeX{} on \verb"\paragraph" macro to make it more like a sectioning command. Though we could get benefit from removing all the trailing newline after this command, the caveats are obvious.
-%   Like a sectioning command, it will goes to the auxilary file \verb".toc". Since the \verb"beamer" class has a different mechanism on treating Table of Contents, the output contents for paragraph will be inconsistent. It is afraid to not only add burden on processing and also unexpected behavior for beamer in \verb"\tableofcontents" and more.
+%   Like a sectioning command, it will goes to the auxilary file \verb".toc". Since the \verb"beamer" class has a different mechanism on treating Table of Contents, the output contents for paragraph will be inconsistent. It is afraid that not only extra burden on processing will be made, but also unexpected behavior for beamer in \verb"\tableofcontents" will shown.
 %   And a sectioning command cannot go anywhere, especially in an environment like \verb"center" and \verb"itemize" lists. The best practice for \LaTeX{} is not using \verb"\paragraph" and \verb"\subparagraph". As mentioned, The macro here is mainly for migration compatibility to create a similar output. You could use \verb"\alert" or \verb"\highlight" (a more general one, \verb"\colorbox") for highlighting the text.
 % \end{macro}
 %
 % \begin{macro}{stampbox}
 %   Make a stampbox border, which is a decoration advice from SJTU VI. It has the dependency on \verb"stampline" from \verb"sjtuvi" package.
+%   TODO: use tikzpicture to refactor the code.
 %    \begin{macrocode}
 \newtcolorbox{stampbox}[1][cprimary]{%
   capture=hbox,
@@ -373,12 +374,13 @@
   sharp corners,
   top=0mm,
   bottom=0mm,
+  right*=0.5mm,
   title=#2,
   colback=cprimary!5,
   colframe=cprimary!80,
   overlay={
     \begin{tcbclipinterior}\fill[cprimary!20]%
-      (frame.south west) rectangle ([xshift=5mm]frame.north west);
+      (frame.south west) rectangle ([xshift=5.5mm]frame.north west);
     \end{tcbclipinterior}
   }
 }

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -311,7 +311,7 @@
 %   Since beamer has deleted \verb"\paragraph" macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from \verb"article" class.
 %   If it is the end of paragraph, the trailing space will be removed by \TeX{}. The additional newline after this command will be get an output rather than the original sectioning command.
 %    \begin{macrocode}
-\providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\hspace{0.5em}}
+\providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\space}
 %    \end{macrocode}
 %   NOTE: We could use the original \LaTeX{} macro \verb"\@startsection" on \verb"\paragraph" to make it more like a sectioning command. Though we could get benefit from removing all the trailing newline after this command, the caveats are obvious.
 %   Like a sectioning command, it will goes to the auxilary file \verb".toc". Since the \verb"beamer" class has a different mechanism on treating Table of Contents, the output contents for paragraph will be inconsistent. It is afraid that not only extra burden on processing will be made, but also unexpected behavior for beamer in \verb"\tableofcontents" will occur.

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -296,30 +296,20 @@
 %    \end{macrocode}
 %
 % \begin{macro}{\highlight}
-%   Highlight the given text. Create a primary color background block with white as foreground.
+%   Highlight the given text. Create a light primary color background block without modifying the text color. This method is more familiar with the usual way on highlighting.
+%   Since \verb"structure" is globally available, we can use it to set the background color without introducing first. Set to 10\% of the structure to make enough contrast even if it is in a block (which is 30\% light).
+%   Receives one optional paramenter to specify the background color. If you want to modify the color it is highlighted, modify the text color manually.
 %    \begin{macrocode}
-\newtcbox{\highlight}[1][cprimary]{
-  on line,
-  arc=0pt,
-  colback=#1,
-  colupper=white,
-  boxrule=0pt,
-  boxsep=0pt,
-  left=4pt,
-  right=4pt,
-  top=2pt,
-  bottom=2pt
-}
+\newcommand{\highlight}[2][structure!10]{\colorbox{#1}{#2}}
 %    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{\paragraph}
-%   Use \verb"\highlight" macro for making contrast.
+%   Making contrast through dark background color and white forground, which confirms the visual identity system on making use of vi shapes.
 %   Since beamer has deleted \verb"\paragraph" macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from \verb"article" class.
+%   If it is the end of paragraph, the trailing space will be removed by \TeX{}.
 %    \begin{macrocode}
-\providecommand{\paragraph}[1]{
-  \highlight{#1}~
-}
+\providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\hspace{0.5em}}
 %    \end{macrocode}
 % \end{macro}
 %

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -298,28 +298,24 @@
 % \begin{macro}{\highlight}
 %   Highlight the given text. Create a \verb"structure" color background block with white text.
 %   Receives one optional paramenter to specify the background color. If you want to modify the color of the text, use \verb"\color{}" command or \verb"\textcolor{}{}" command for your text.
-%   For a general use, use \verb"\colorbox{}{}" from \verb"xcolor" directly.
+%   For a general use and better control, use \verb"\colorbox{}{}" from \verb"xcolor" directly.
 %    \begin{macrocode}
 \newcommand{\highlight}[2][structure]{\textcolor{white}{\colorbox{#1}{#2}}}
 %    \end{macrocode}
 %   Since \verb"structure" is globally available, we can use it to set the background color without introducing first.
+%   We decided to use a dark background rather than the traditional light highlight marker like color, since the former one is better for presentation highlighting and the later one is more like the overlay effect in \verb"beamer".
 % \end{macro}
 %
 % \begin{macro}{\paragraph}
 %   Making a new paragraph through dark background color and white forground, which confirms the visual identity system on making use of vi shapes.
 %   Since beamer has deleted \verb"\paragraph" macro in this class, this template defines a macro for that to indicate it is another point and more paragraph-like. It is useful for the migration from \verb"article" class.
+%   If it is the end of paragraph, the trailing space will be removed by \TeX{}. The additional newline after this command will be get an output rather than the original sectioning command.
 %    \begin{macrocode}
-\def\paragraph{
+\providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\hspace{0.5em}}
 %    \end{macrocode}
-%   Though we could define \verb"\paragraph" like \verb"\highlight" above, we decided to use the orginal \LaTeX{} definition on \verb"\paragraph".
-%   Because the the internal macro \verb"\@startsection" will remove the following spaces and newlines, which is the behavior of \LaTeX{} paragraph as the sectioning command.
-%    \begin{macrocode}
-  \@startsection{paragraph}{4}{\z@}
-                {3.25ex \@plus1ex \@minus.2ex}
-                {-1em}%
-                {\color{white}\colorbox{structure}}
-}
-%    \end{macrocode}
+%   NOTE: We could use the original \LaTeX{} on \verb"\paragraph" macro to make it more like a sectioning command. Though we could get benefit from removing all the trailing newline after this command, the caveats are obvious.
+%   Like a sectioning command, it will goes to the auxilary file \verb".toc". Since the \verb"beamer" class has a different mechanism on treating Table of Contents, the output contents for paragraph will be inconsistent. It is afraid to not only add burden on processing and also unexpected behavior for beamer in \verb"\tableofcontents" and more.
+%   And a sectioning command cannot go anywhere, especially in an environment like \verb"center" and \verb"itemize" lists. The best practice for \LaTeX{} is not using \verb"\paragraph" and \verb"\subparagraph". As mentioned, The macro here is mainly for migration compatibility to create a similar output. You could use \verb"\alert" or \verb"\highlight" (a more general one, \verb"\colorbox") for highlighting the text.
 % \end{macro}
 %
 % \begin{macro}{stampbox}
@@ -346,7 +342,7 @@
 %    \end{macrocode}
 % \end{macro}
 %
-%   Declare the basic listing highlighter. \verb"columns" is set to \verb"flexible" to avoid ugly grid alignment. \verb"breaklines" is set to enable line wrapping.
+%   Declare the basic listings highlighter. \verb"columns" is set to \verb"flexible" to avoid ugly grid alignment. \verb"breaklines" is set to enable line wrapping.
 %    \begin{macrocode}
 \lstset{
   basicstyle=\ttfamily\small,

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -313,14 +313,13 @@
 %    \begin{macrocode}
 \providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\hspace{0.5em}}
 %    \end{macrocode}
-%   NOTE: We could use the original \LaTeX{} on \verb"\paragraph" macro to make it more like a sectioning command. Though we could get benefit from removing all the trailing newline after this command, the caveats are obvious.
-%   Like a sectioning command, it will goes to the auxilary file \verb".toc". Since the \verb"beamer" class has a different mechanism on treating Table of Contents, the output contents for paragraph will be inconsistent. It is afraid that not only extra burden on processing will be made, but also unexpected behavior for beamer in \verb"\tableofcontents" will shown.
+%   NOTE: We could use the original \LaTeX{} macro \verb"\@startsection" on \verb"\paragraph" to make it more like a sectioning command. Though we could get benefit from removing all the trailing newline after this command, the caveats are obvious.
+%   Like a sectioning command, it will goes to the auxilary file \verb".toc". Since the \verb"beamer" class has a different mechanism on treating Table of Contents, the output contents for paragraph will be inconsistent. It is afraid that not only extra burden on processing will be made, but also unexpected behavior for beamer in \verb"\tableofcontents" will occur.
 %   And a sectioning command cannot go anywhere, especially in an environment like \verb"center" and \verb"itemize" lists. The best practice for \LaTeX{} is not using \verb"\paragraph" and \verb"\subparagraph". As mentioned, The macro here is mainly for migration compatibility to create a similar output. You could use \verb"\alert" or \verb"\highlight" (a more general one, \verb"\colorbox") for highlighting the text.
 % \end{macro}
 %
 % \begin{macro}{stampbox}
 %   Make a stampbox border, which is a decoration advice from SJTU VI. It has the dependency on \verb"stampline" from \verb"sjtuvi" package.
-%   TODO: use tikzpicture to refactor the code.
 %    \begin{macrocode}
 \newtcolorbox{stampbox}[1][cprimary]{%
   capture=hbox,
@@ -389,12 +388,12 @@
 %
 % \begin{macro}{\highlightline}
 %    Highlight the current line with a light background. 
-%    It is useful for the codeblock environment with \verb"escapechar" option to insert the command for highlighting.
+%    It is useful for the codeblock environment with \verb"escapechar" option to insert the command for highlighting. For example, set the optional argument \verb"escapechar=|", and insert \verb"|\highlightline|" at the first position in the line you want to highlight.
 %    \begin{macrocode}
 \providecommand{\highlightline}{\rlap{\color{ctertiary!40}\rule[-\dp\strutbox]{\linewidth}{\baselineskip}}}
 %    \end{macrocode}
+%    For better support in code environment, you should try out the \verb"highlightlines" in minted package, but performance drop is expected.
 % \end{macro}
-%
 %
 %   Extra Support for pgfplots and pgfplotstable (if loaded in the main file).
 %    \begin{macrocode}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -387,6 +387,15 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\highlightline}
+%    Highlight the current line with a light background. 
+%    It is useful for the codeblock environment with \verb"escapechar" option to insert the command for highlighting.
+%    \begin{macrocode}
+\providecommand{\highlightline}{\rlap{\color{ctertiary!40}\rule[-\dp\strutbox]{\linewidth}{\baselineskip}}}
+%    \end{macrocode}
+% \end{macro}
+%
+%
 %   Extra Support for pgfplots and pgfplotstable (if loaded in the main file).
 %    \begin{macrocode}
 \AtEndPreamble{%

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/19 sjtubeamer outer theme v2.5.3]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/02/24 sjtubeamer outer theme v2.5.4]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/02/19 sjtubeamer parent theme v2.5.3]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/02/24 sjtubeamer parent theme v2.5.4]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/02/19 cover library for sjtubeamer v2.5.3]
+\ProvidesPackage{sjtucover}[2022/02/24 cover library for sjtubeamer v2.5.4]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -84,11 +84,13 @@
 %   \verb"fadings" provides the method to create a fading mask; 
 %   \verb"decoration.pathmorphing" provides the interface to user-define a decoration.
 %   \verb"external" provides the way for tikz externalization, which will reduce the number of repetitive rendering with the cached pdf.
+%   \verb"backgrounds" provides the way to make a scope as a background to draw later.
 %    \begin{macrocode}
 \RequirePackage{tikz}
 \usetikzlibrary{fadings}
 \usetikzlibrary{decorations.pathmorphing}
 \usetikzlibrary{external}
+\usetikzlibrary{backgrounds}
 %    \end{macrocode}
 %
 % \subsubsection{Color Definition}
@@ -167,31 +169,49 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\stamptext}
-%    Make a stamp unit surround the text.
-%    Use one Chinese character or at most two English characters for the argument.
+% \begin{macro}{\getheightofnode}
+%    A helper macro to get the height of a tikz node \#2 and store it in length \#1. You have to declare the length \#1 first by using \verb"\newlength".
 %    \begin{macrocode}
-\providecommand{\stamptext}[2][]{
+\def\getheightofnode#1#2{%
+  \pgfextracty{#1}{\pgfpointanchor{#2}{north}}%
+  \pgfextracty{\pgf@ya}{\pgfpointanchor{#2}{south}}%
+  \addtolength{#1}{-\pgf@ya}
+}
+%    \end{macrocode}
+%    The macro is similar to \verb"\tcbsetmacroheightofnode" from \verb"skins" library of \verb"tcolorbox", but for decoupling reasons, use a native pgf command to calculate that without loading \verb"tcolorbox" in this style file.
+% \end{macro}
+%
+% \begin{macro}{\stamptext}
+%    Make a stamp unit surround the text. Similar to \verb"\highlight" command in inner theme with limitations on number of characters.
+%    Use one Chinese character or at most two English characters for the argument.
+%    Use an optional argument to set the background color, default is \verb"structure". Avoid using this macro if you are not in \verb"beamer" class, or use a defined color for background.
+%    \begin{macrocode}
+\providecommand{\stamptext}[2][structure]{
   {
     \tikzset{external/export=false}
     \begin{tikzpicture}[baseline=(nodetext.base)]
-      \def\s{2cm}
-      \fill [structure]
-        (-0.25*\s,0)
-        -- (-0.17*\s,0.06*\s)
-        -- (-0.17*\s,0.1*\s)
-        -- (0.17*\s,0.1*\s)
-        -- (0.17*\s,0.06*\s)
-        -- (0.25*\s,0)
-        -- (0.17*\s,-0.06*\s)
-        -- (0.17*\s,-0.1*\s)
-        -- (-0.17*\s,-0.1*\s)
-        -- (-0.17*\s,-0.06*\s) -- cycle;
       \node [white] (nodetext) at (0,0) {#2};
+      \newlength{\s}
+      \getheightofnode{\s}{nodetext}
+      \scoped[on background layer]
+        \fill [#1]
+          (-1.25*\s,0)
+          -- (-0.85*\s,0.3*\s)
+          -- (-0.85*\s,0.5*\s)
+          -- (0.85*\s,0.5*\s)
+          -- (0.85*\s,0.3*\s)
+          -- (1.25*\s,0)
+          -- (0.85*\s,-0.3*\s)
+          -- (0.85*\s,-0.5*\s)
+          -- (-0.85*\s,-0.5*\s)
+          -- (-0.85*\s,-0.3*\s) -- cycle;
     \end{tikzpicture} 
   }
 }
 %    \end{macrocode}
+%    Unlike \verb"\highlight" to make use of \verb"\colorbox" from \verb"xcolor". \verb"\stamptext" has to use Ti\emph{k}Z for drawing the vi shape. And the vi rules that the shape could not be resized to a different aspect ratio. So the only available mode is scaling.
+%    The tradeof is that the text length has to be limited.
+%    Use a group to disable caching.
 % \end{macro}
 %
 % \begin{macro}{stamp}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -166,10 +166,17 @@
 % \begin{macro}{\stamptext}
 %    Use one Chinese character or at most two English characters for the text argument.
 %    Make a stamp unit surround the text. Similar to \verb"\highlight" command in inner theme with limitations on number of characters.
-%    Use an optional argument to set the background color, default is \verb"structure". Avoid using this macro if you are not in \verb"beamer" class, or use a defined color for background.
+%    Use an optional argument to set the background color, default is \verb"structure" or \verb"sjtuRedPrimary".
 %    \begin{macrocode}
 \providecommand{\stamptext}[2][structure]{
   {
+%    \end{macrocode}
+%    If the color is not defined, it will fallback to color \verb"sjtuRedPrimary" in this pacakge. Notice if your color is not defined, it will not get an error through this manner.
+%    \begin{macrocode}
+    \providecolor{#1}{named}{sjtuRedPrimary}
+%    \end{macrocode}
+%    Disable caching in this group.
+%    \begin{macrocode}
     \tikzset{external/export=false}
     \begin{tikzpicture}[baseline=(nodetext.base)]
       \node [white] (nodetext) at (0,0) {#2};
@@ -201,7 +208,6 @@
 %    \end{macrocode}
 %    Unlike \verb"\highlight" to make use of \verb"\colorbox" from \verb"xcolor". \verb"\stamptext" has to use Ti\emph{k}Z for drawing the vi shape. And the vi rules that the shape could not be resized to a different aspect ratio. So the only available mode is scaling.
 %    The tradeof is that the text length has to be limited.
-%    Use a group to disable caching.
 % \end{macro}
 %
 % \begin{macro}{\sjtubeamer@compatible}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/02/19 Visual Identity System library for sjtubeamer v2.5.3]
+\ProvidesPackage{sjtuvi}[2022/02/24 Visual Identity System library for sjtubeamer v2.5.4]
 %</package>
 % \fi
 % \CheckSum{0}
@@ -162,28 +162,10 @@
 %
 %
 % \subsubsection{Shape Declarations}
-% \begin{macro}{\sjtubeamer@compatible}
-% For \TeX Live 2018 and even older, it is \emph{not} compatible to use the patterns.meta library for making user-defined patterns. And fading is not available for caching. Please consider \verb"\def\sjtubeamer@compatible{false}" to match the following condition checking. Remember to use \verb"\makeatletter" and \verb"\makeatother" in \LaTeX{}.
-%    \begin{macrocode}
-\def\sjtubeamer@compatible@false{false}
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}{\getheightofnode}
-%    A helper macro to get the height of a tikz node \#2 and store it in length \#1. You have to declare the length \#1 first by using \verb"\newlength".
-%    \begin{macrocode}
-\def\getheightofnode#1#2{%
-  \pgfextracty{#1}{\pgfpointanchor{#2}{north}}%
-  \pgfextracty{\pgf@ya}{\pgfpointanchor{#2}{south}}%
-  \addtolength{#1}{-\pgf@ya}
-}
-%    \end{macrocode}
-%    The macro is similar to \verb"\tcbsetmacroheightofnode" from \verb"skins" library of \verb"tcolorbox", but for decoupling reasons, use a native pgf command to calculate that without loading \verb"tcolorbox" in this style file.
-% \end{macro}
 %
 % \begin{macro}{\stamptext}
+%    Use one Chinese character or at most two English characters for the text argument.
 %    Make a stamp unit surround the text. Similar to \verb"\highlight" command in inner theme with limitations on number of characters.
-%    Use one Chinese character or at most two English characters for the argument.
 %    Use an optional argument to set the background color, default is \verb"structure". Avoid using this macro if you are not in \verb"beamer" class, or use a defined color for background.
 %    \begin{macrocode}
 \providecommand{\stamptext}[2][structure]{
@@ -191,8 +173,16 @@
     \tikzset{external/export=false}
     \begin{tikzpicture}[baseline=(nodetext.base)]
       \node [white] (nodetext) at (0,0) {#2};
+%    \end{macrocode}
+% Get the height of a tikz node \verb"nodetext" and store it in length \verb"\s". It is similar to \verb"\tcbsetmacroheightofnode" from \verb"skins" library of \verb"tcolorbox", but for decoupling reasons, use a native pgf command to calculate that without loading \verb"tcolorbox" in this style file.
+%    \begin{macrocode}
       \newlength{\s}
-      \getheightofnode{\s}{nodetext}
+      \pgfextracty{\s}{\pgfpointanchor{nodetext}{north}}%
+      \pgfextracty{\pgf@ya}{\pgfpointanchor{nodetext}{south}}%
+      \addtolength{\s}{-\pgf@ya}
+%    \end{macrocode}
+% Use a scope with \verb"on background layer" to adjust the order of rendering.
+%    \begin{macrocode}
       \scoped[on background layer]
         \fill [#1]
           (-1.25*\s,0)
@@ -212,6 +202,13 @@
 %    Unlike \verb"\highlight" to make use of \verb"\colorbox" from \verb"xcolor". \verb"\stamptext" has to use Ti\emph{k}Z for drawing the vi shape. And the vi rules that the shape could not be resized to a different aspect ratio. So the only available mode is scaling.
 %    The tradeof is that the text length has to be limited.
 %    Use a group to disable caching.
+% \end{macro}
+%
+% \begin{macro}{\sjtubeamer@compatible}
+% For \TeX Live 2018 and even older, it is \emph{not} compatible to use the patterns.meta library for making user-defined patterns. And fading is not available for caching. Please consider \verb"\def\sjtubeamer@compatible{false}" to match the following condition checking. Remember to use \verb"\makeatletter" and \verb"\makeatother" in \LaTeX{}.
+%    \begin{macrocode}
+\def\sjtubeamer@compatible@false{false}
+%    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{stamp}
@@ -269,7 +266,7 @@
   }
 \fi
 %    \end{macrocode}
-%    Avoid using macro in code section for performance reasons.
+%    Avoid calling macros in code section for performance reasons.
 % \end{macro}
 %
 % \begin{macro}{\stamparray}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -167,6 +167,33 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\stamptext}
+%    Make a stamp unit surround the text.
+%    Use one Chinese character or at most two English characters for the argument.
+%    \begin{macrocode}
+\providecommand{\stamptext}[2][]{
+  {
+    \tikzset{external/export=false}
+    \begin{tikzpicture}[baseline=(nodetext.base)]
+      \def\s{2cm}
+      \fill [structure]
+        (-0.25*\s,0)
+        -- (-0.17*\s,0.06*\s)
+        -- (-0.17*\s,0.1*\s)
+        -- (0.17*\s,0.1*\s)
+        -- (0.17*\s,0.06*\s)
+        -- (0.25*\s,0)
+        -- (0.17*\s,-0.06*\s)
+        -- (0.17*\s,-0.1*\s)
+        -- (-0.17*\s,-0.1*\s)
+        -- (-0.17*\s,-0.06*\s) -- cycle;
+      \node [white] (nodetext) at (0,0) {#2};
+    \end{tikzpicture} 
+  }
+}
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{stamp}
 %	  Declare stamp pattern to make a stamp array.
 %
@@ -222,6 +249,7 @@
   }
 \fi
 %    \end{macrocode}
+%    Avoid using macro in code section for performance reasons.
 % \end{macro}
 %
 % \begin{macro}{\stamparray}

--- a/src/support/tutorial/commonheader.tex
+++ b/src/support/tutorial/commonheader.tex
@@ -4,15 +4,10 @@
 \def\sjtubeamer@compatible{false}
 \makeatother
 \usepackage{sjtuvi}     % contains TikZ. 
-\usepackage[cn]{sjtucover}    % temporarily use cn config, since the justification will first check if it is ctexbeamer than use caching.
+\usepackage[cn]{sjtucover}    % temporarily use cn config, since the justification will first check if it is ctexbeamer then use caching.
 \usepackage{tcolorbox}
 \tcbuselibrary{skins}
 \tcbuselibrary{listingsutf8}
-\makeatletter
-\AtEndPreamble{     % patch the langauge if it is ctexbeamer
-    \def\bottomthanks{谢\,谢}
-}
-\makeatother
 \begin{document}
 % intentionally left blank
 \end{document}

--- a/src/support/tutorial/commonheader.tex
+++ b/src/support/tutorial/commonheader.tex
@@ -3,8 +3,8 @@
 \makeatletter
 \def\sjtubeamer@compatible{false}
 \makeatother
-\usepackage[cn]{sjtuvi}     % contains TikZ. temporarily use cn config, since the justification will first check if it is ctexbeamer than use caching.
-\usepackage{sjtucover}
+\usepackage{sjtuvi}     % contains TikZ. 
+\usepackage[cn]{sjtucover}    % temporarily use cn config, since the justification will first check if it is ctexbeamer than use caching.
 \usepackage{tcolorbox}
 \tcbuselibrary{skins}
 \tcbuselibrary{listingsutf8}

--- a/src/support/tutorial/commonheader.tex
+++ b/src/support/tutorial/commonheader.tex
@@ -3,7 +3,7 @@
 \makeatletter
 \def\sjtubeamer@compatible{false}
 \makeatother
-\usepackage{sjtuvi}     % contains TikZ
+\usepackage[cn]{sjtuvi}     % contains TikZ. temporarily use cn config, since the justification will first check if it is ctexbeamer than use caching.
 \usepackage{sjtucover}
 \usepackage{tcolorbox}
 \tcbuselibrary{skins}

--- a/src/support/tutorial/step10.tex
+++ b/src/support/tutorial/step10.tex
@@ -6,7 +6,7 @@
 
   \paragraph{可适应性} 适应多种 \emph{外样式 Outer theme}。
 
-  \highlight[csecondary]{可扩展性}~
+  \highlight[csecondary]{可扩展性}
   用户可以添加自己的\alert{模板}。
 
   \stamptext{注} SJTUBeamer 的功能在其他模板中可能不通用。

--- a/src/support/tutorial/step10.tex
+++ b/src/support/tutorial/step10.tex
@@ -4,9 +4,9 @@
 \begin{frame}
   \frametitle{SJTUBeamer 的功能}
 
-  \paragraph{可适应} 适应多种 \emph{外样式 Outer theme}。
+  \paragraph{可适应性} 适应多种 \emph{外样式 Outer theme}。
 
-  \highlight[csecondary]{可扩展}~
+  \highlight[csecondary]{可扩展性}~
   用户可以添加自己的\alert{模板}。
 
   \stamptext{注} SJTUBeamer 的功能在其他模板中可能不通用。

--- a/src/support/tutorial/step10.tex
+++ b/src/support/tutorial/step10.tex
@@ -4,9 +4,9 @@
 \begin{frame}
   \frametitle{SJTUBeamer 的功能}
 
-  \paragraph{可适应性} 适应多种 \emph{外样式 Outer theme}。
+  \paragraph{可适应} 适应多种 \emph{外样式 Outer theme}。
 
-  \highlight[csecondary]{可扩展性}~
+  \highlight[csecondary]{可扩展}~
   用户可以添加自己的\alert{模板}。
 
   \stamptext{注} SJTUBeamer 的功能在其他模板中可能不通用。

--- a/src/support/tutorial/step10.tex
+++ b/src/support/tutorial/step10.tex
@@ -4,10 +4,11 @@
 \begin{frame}
   \frametitle{SJTUBeamer 的功能}
 
-  \paragraph{可适应性} 适应多种
-  \emph{外样式 Outer theme}。
+  \paragraph{可适应性} 适应多种 \emph{外样式 Outer theme}。
 
   \highlight[csecondary]{可扩展性}~
   用户可以添加自己的\alert{模板}。
+
+  \stamptext{注} SJTUBeamer 的功能在其他模板中可能不通用。
 \end{frame}
 \end{document}

--- a/src/support/tutorial/step12.tex
+++ b/src/support/tutorial/step12.tex
@@ -1,5 +1,5 @@
 \documentclass{ctexbeamer}
-\usetheme[min]{sjtubeamer}
+\usetheme[min,infolines]{sjtubeamer}
 \begin{document}
 \begin{frame}
   \frametitle{图}

--- a/src/support/tutorial/step12.tex
+++ b/src/support/tutorial/step12.tex
@@ -6,7 +6,8 @@
   \begin{figure}
     \centering
     \begin{stampbox}
-      \includegraphics[height = 0.3\textheight]
+      \includegraphics
+      [height=.3\textheight]
       {../plant.jpg}
     \end{stampbox}
     \caption{图片标题}

--- a/src/support/tutorial/step12.tex
+++ b/src/support/tutorial/step12.tex
@@ -6,8 +6,7 @@
   \begin{figure}
     \centering
     \begin{stampbox}
-      \includegraphics
-      [height=0.3\textheight]
+      \includegraphics[height = 0.3\textheight]
       {../plant.jpg}
     \end{stampbox}
     \caption{图片标题}


### PR DESCRIPTION
本 PR 重构了高亮区块：
- `\highlight[]{}` 和 `\paragraph` 用 `xcolor` 中的 `\colorbox` 重写，不再使用 `tcolorbox` 以期得到更好的性能。
- `codeblock` 边距做出微小变动，并添加 `\highlightline` 宏可用于高亮当前代码行。
- `\stamptext{}` 添加该宏用于生成 vi 图形区块。
<img width="298" alt="image" src="https://user-images.githubusercontent.com/61653082/155451017-d01f93ea-ac6f-405d-a0ca-d8a256119f1d.png">
