### PR TITLE
fix: codeblock and overlay for highlight

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -39,7 +39,7 @@
 		"scope": "doctex,tex",
 		"prefix": "\\coverpage",
 		"body": "\\coverpage{$1}",
-		"description": "Common command for \\titlepage and \\bottompage. Disable externalization for generating title page and bottom page, locally.\n"
+		"description": "Common command for \\titlepage and \\bottompage, and more.\n"
 	},
 	"definecover": {
 		"scope": "doctex,tex",
@@ -74,8 +74,8 @@
 	"highlightline": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\highlightline",
-		"body": "\\highlightline",
-		"description": "Highlight the current line with a light background. \nIt is useful for the codeblock environment with escapechar option to insert the command for highlighting. For example, set the optional argument escapechar=|, and insert |\\highlightline| at the first position in the line you want to highlight.\n"
+		"body": "\\highlightline{$1}",
+		"description": "Highlight the current line with a light background. \nIt is useful for the codeblock environment with escapechar option to insert the command for highlighting. For example, set the optional argument escapechar=|, and insert |\\highlightline| at the first position in the line you want to highlight.\nYou could use overlay specification for this macro.\n"
 	},
 	"codeblockinput": {
 		"scope": "doctex,tex,latex",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -50,8 +50,8 @@
 	"highlight": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\highlight",
-		"body": "\\highlight[${1:structure}]{$2}",
-		"description": "Highlight the given text. Create a structure color background block with white text.\nReceives one optional paramenter to specify the background color. If you want to modify the color of the text, use \\color{} command or \\textcolor{}{} command for your text.\nFor a general use and better control, use \\colorbox{}{} from xcolor directly.\n"
+		"body": "\\highlight<$3>[${1:structure}]{$2}",
+		"description": "Highlight the given text. Create a structure color background block with white text.\nReceives one optional paramenter to specify the background color. If you want to modify the color of the text, use \\color{} command or \\textcolor{}{} command for your text.\nFor a general use and better control, use \\colorbox{}{} from xcolor directly.\nOverlay option can be specified as well.\n"
 	},
 	"paragraph": {
 		"scope": "doctex,tex,latex",
@@ -74,7 +74,7 @@
 	"highlightline": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\highlightline",
-		"body": "\\highlightline{$1}",
+		"body": "\\highlightline<$1>",
 		"description": "Highlight the current line with a light background. \nIt is useful for the codeblock environment with escapechar option to insert the command for highlighting. For example, set the optional argument escapechar=|, and insert |\\highlightline| at the first position in the line you want to highlight.\nYou could use overlay specification for this macro.\n"
 	},
 	"codeblockinput": {

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -69,7 +69,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\n\\begin{codeblock",
 		"body": "\n\\begin{codeblock}[${1:}]{$2}\n\t$3\n\\end{codeblock}\n",
-		"description": "Code block environment is made for presenting code in an obvious way.\nThe first optional parameter is passed to listing, which mostly sets the language to highlight, see the listings package for more details. \nThe second required parameter receives the title to make.\nADVANCED TIP: For longer typeset, remove the frame environment around the code input for occupying cross the pages. If you use lstlisting environment directly, no numbering is preset so you need to set the number manually for this basic command.\n"
+		"description": "Code block environment is made for presenting code in an obvious way.\nThe first optional parameter is passed to listing, which mostly sets the language to highlight, see the listings package for more details. \nThe second required parameter receives the title to make.\nADVANCED TIP: For longer typeset, use lstlisting environment directly and remove the frame environment around the code input for occupying cross the pages. No numbering is preset so you need to set the number manually for this basic command.\n"
 	},
 	"highlightline": {
 		"scope": "doctex,tex,latex",
@@ -81,7 +81,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\\codeblockinput",
 		"body": "\\codeblockinput[${1:}]{$2}{$3}{$4}",
-		"description": "Code block environment for external file input. The same style like codeblock.\nThe first optional parameter is passed to listing.\nThe second required parameter receives the title to make.\nThe third required paramter receives the file to typeset.\nADVANCED TIP: For longer typeset, remove the frame environment around the code input for occupying cross the pages. If you use lstinputlisting command directly, no numbering is preset so you need to set the number manually for this basic command.\n"
+		"description": "Code block environment for external file input. The same style like codeblock.\nThe first optional parameter is passed to listing.\nThe second required parameter receives the title to make.\nThe third required paramter receives the file to typeset.\nADVANCED TIP: For longer typeset, use lstinputlisting command directly and remove the frame environment around the code input for occupying cross the pages. No numbering is preset so you need to set the number manually for this basic command.\n"
 	},
 	"sjtubeamer@outer@nav": {
 		"scope": "doctex,tex",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/03/10 sjtubeamer color theme v2.5.5]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/03/10 sjtubeamer color theme v2.5.6]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/03/10 sjtubeamer font theme v2.5.5]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/03/10 sjtubeamer font theme v2.5.6]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -124,7 +124,7 @@
 \if\EqualOption{inner}{cover}{min}\else
   \setbeamertemplate{blocks}[rounded]
 \fi
-\newcommand{\highlight}[2][structure]{\textcolor{white}{\colorbox{#1}{#2}}}
+\newcommand<>{\highlight}[2][structure]{\only#3{\textcolor{white}{\colorbox{#1}{#2}}}}
 \providecommand{\paragraph}[1]{\textcolor{white}{\colorbox{structure}{#1}}\space}
 \newtcolorbox{stampbox}[1][cprimary]{%
   capture=hbox,

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/03/10 sjtubeamer inner theme v2.5.5]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/03/10 sjtubeamer inner theme v2.5.6]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}
@@ -57,7 +57,6 @@
 \RequirePackage{tcolorbox}
 \tcbuselibrary{skins}
 \tcbuselibrary{listingsutf8}
-\tcbuselibrary{breakable}
 \tcbset{shield externalize}
 \RequirePackage{sjtucover}
 \setbeamertemplate{logo}[\sjtubeamer@inner@cover]
@@ -165,33 +164,6 @@
     #1,
   },
   enhanced,
-  breakable,
-  sharp corners,
-  top=0mm,
-  bottom=0mm,
-  right*=0.5mm,
-  title=#2,
-  colback=cprimary!5,
-  colframe=cprimary!80,
-  overlay={
-    \begin{tcbclipinterior}\fill[cprimary!20]%
-      (frame.south west) rectangle ([xshift=5.5mm]frame.north west);
-    \end{tcbclipinterior}
-  }
-}
-\providecommand{\highlightline}{\rlap{\color{structure!25}\rule[-\dp\strutbox]{\linewidth}{\baselineskip}}}
-\newtcbinputlisting{\codeblockinput}[3][]{
-  listing only,
-  listing engine=listings,
-  listing options={
-    numbers=left,
-    numberstyle=\color{cprimary!80}\ttfamily\scriptsize,
-    numbersep=5pt,
-    #1,
-  },
-  listing file=#3,
-  enhanced,
-  breakable,
   sharp corners,
   top=0mm,
   bottom=0mm,
@@ -206,6 +178,30 @@
   }
 }
 \newcommand<>{\highlightline}{\only#1{\rlap{\color{structure!25}\rule[-\dp\strutbox]{\linewidth}{\baselineskip}}}}
+\newtcbinputlisting{\codeblockinput}[3][]{
+  listing only,
+  listing engine=listings,
+  listing options={
+    numbers=left,
+    numberstyle=\color{cprimary!80}\ttfamily\scriptsize,
+    numbersep=5pt,
+    #1,
+  },
+  listing file=#3,
+  enhanced,
+  sharp corners,
+  top=0mm,
+  bottom=0mm,
+  right*=0.5mm,
+  title=#2,
+  colback=cprimary!5,
+  colframe=cprimary!80,
+  overlay={
+    \begin{tcbclipinterior}\fill[cprimary!20]%
+      (frame.south west) rectangle ([xshift=5.5mm]frame.north west);
+    \end{tcbclipinterior}
+  }
+}
 \AtEndPreamble{%
   \@ifpackageloaded{pgfplots}{%
     \pgfplotsset{

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -79,6 +79,7 @@
 \def\coverpage#1{
   {
     \tikzset{external/export=false}
+    \setlength{\parindent}{0em}
     \ifdim\beamer@sidebarwidth=0pt %
       \usebeamertemplate*{#1}
     \else
@@ -204,6 +205,7 @@
     \end{tcbclipinterior}
   }
 }
+\newcommand<>{\highlightline}{\only#1{\rlap{\color{structure!25}\rule[-\dp\strutbox]{\linewidth}{\baselineskip}}}}
 \AtEndPreamble{%
   \@ifpackageloaded{pgfplots}{%
     \pgfplotsset{

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/03/10 sjtubeamer outer theme v2.5.5]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/03/10 sjtubeamer outer theme v2.5.6]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/03/10 sjtubeamer parent theme v2.5.5]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/03/10 sjtubeamer parent theme v2.5.6]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/contrib/minted/minted.tex
+++ b/contrib/minted/minted.tex
@@ -1,4 +1,4 @@
-\documentclass{ctexbeamer}
+\documentclass[aspectsratio=169]{ctexbeamer}
 \usetheme{sjtubeamer}     % 不必使用 my 选项
 \usemytheme{minted}       % 引入本插件，可以添加 draft 选项
 \begin{document}
@@ -11,7 +11,7 @@
   你可以通过临时添加 \texttt{draft} 选项来减少编译时间。
   \codeblockinputminted[firstline=2, lastline=3]{}{latex}{minted.tex}
   不仅可以使用 \texttt{\textbackslash{}codeblockinputminted} 用于抄录外部文件，还可以使用 \texttt{codeblockminted} 环境使用 \texttt{minted} 引擎抄录文件内代码。
-  \codeblockinputminted[firstline=15, lastline=17]{codeblockminted 环境（部分）}{latex}{minted.tex}
+  \codeblockinputminted[firstline=16, lastline=18]{codeblockminted 环境（部分）}{latex}{minted.tex}
 \end{frame}
 \begin{frame}[fragile]  % fragile
   \begin{codeblockminted}[]{C++ 代码}{cpp}

--- a/contrib/minted/sjtubeamerthememinted.ltx
+++ b/contrib/minted/sjtubeamerthememinted.ltx
@@ -15,6 +15,8 @@
 %% ------------------------------------------------------------------------
 \ProvidesFile{sjtubeamerthememinted.ltx}[2022/03/10 Minted implementations for codeblock]
 \if\EqualOption{minted}{draft}{true}
+  % minted 会导致编译变慢，启用 draft 将会使得 minted 只采用底层的 fancyvrb 宏包编译。
+  % 可以在一定程度上解决超时问题。仍然推荐只使用 listings 编译。
   \PassOptionsToPackage{draft}{minted}
 \fi
 % 启用 minted
@@ -50,7 +52,6 @@
     #1,
   },
   enhanced,
-  breakable,
   sharp corners,
   top=0mm,
   bottom=0mm,
@@ -79,7 +80,6 @@
   },
   listing only,
   enhanced,
-  breakable,
   sharp corners,
   top=0mm,
   bottom=0mm,

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/03/10 cover library for sjtubeamer v2.5.5]
+\ProvidesPackage{sjtucover}[2022/03/10 cover library for sjtubeamer v2.5.6]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{cn}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -84,6 +84,7 @@
 \definelogo{dlogo}{0}{0}
 \definelogo{vlogo}{0.8}{0.13}
 \definelogo{sjtubg}{0.3}{0.5}
+\definelogo{sjtugate}{0.25}{0.8}
 \providecommand{\stamptext}[2][structure]{
   {
     \providecolor{#1}{named}{sjtuRedPrimary}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/03/10 Visual Identity System library for sjtubeamer v2.5.5]
+\ProvidesPackage{sjtuvi}[2022/03/10 Visual Identity System library for sjtubeamer v2.5.6]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key
@@ -84,7 +84,6 @@
 \definelogo{dlogo}{0}{0}
 \definelogo{vlogo}{0.8}{0.13}
 \definelogo{sjtubg}{0.3}{0.5}
-\definelogo{sjtugate}{0.25}{0.8}
 \providecommand{\stamptext}[2][structure]{
   {
     \providecolor{#1}{named}{sjtuRedPrimary}

--- a/src/build.lua
+++ b/src/build.lua
@@ -189,7 +189,7 @@ function gen_snippets()
                 -- Find TeX style definition, see Coding Style 3.1.2
                 local def_param = string.match(line, "\\def" .. in_macro .. "([#%d]*)")
                 -- Find LaTeX style definition, see Coding Style 3.1.3
-                local comm_decl, comm_param, param_default = string.match(line, "\\(%a+){" .. in_macro .. "}%[?(%d?)%]?(%[?%a*@*\\*%]?)")
+                local comm_decl, comm_param, param_default = string.match(line, "\\(%a+<?>?){" .. in_macro .. "}%[?(%d?)%]?(%[?%a*@*\\*%]?)")
                 if def_param ~= nil then
                     def_param = string.gsub(def_param, "#(%d)", "{$%1}")
                     macro_body = macro_body .. "\\" .. in_macro .. def_param
@@ -203,12 +203,18 @@ function gen_snippets()
                         macro_body = macro_body .. "\\n\\\\begin{" .. in_macro .. "}"
                         captured = 3
                     end
+                    if string.find(comm_decl, "<>") ~= nil then
+                        -- Command has an overlay option.
+                        macro_body = macro_body .. "<$" .. comm_param + 1 .. ">"
+                    end
                     if comm_param > 0 then
                         -- Command has parameters.
                         if param_default ~= "" then
+                            -- Command has a default parameter.
                             param_default = string.gsub(string.sub(param_default, 2, -2),"\\","\\\\") -- remove square brackets
                             macro_body = macro_body .. "[${1:" .. param_default .. "}]"
                         else
+                            -- No default parameter is specified.
                             macro_body = macro_body .. "{$1}"
                         end
                         for i=2,comm_param do
@@ -217,7 +223,7 @@ function gen_snippets()
                     end
                     if captured == 3 then   -- close the environment
                         macro_body = macro_body .. "\\n\\t$" .. comm_param + 1 .. "\\n\\\\end{" .. in_macro .. "}\\n"
-                    elseif string.find(line, "command{") == nil then -- it is a definition method from 3rd party package, which often requires an applying region.
+                    elseif string.find(comm_decl, "command") == nil then -- it is a definition method from 3rd party package, which often requires an applying region.
                         macro_body = macro_body .. "{$" .. comm_param + 1 .. "}"
                     end
                 -- Find begin macrocode environment, see Coding Style 3.3.2

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/03/10 sjtubeamer color theme v2.5.5]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/03/10 sjtubeamer color theme v2.5.6]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/03/10 sjtubeamer font theme v2.5.5]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/03/10 sjtubeamer font theme v2.5.6]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -193,11 +193,21 @@
 %    \end{macrocode}
 %
 %  \begin{macro}{\coverpage}
-%  Common command for \verb"\titlepage" and \verb"\bottompage". Disable externalization for generating title page and bottom page, locally.
+%  Common command for \verb"\titlepage" and \verb"\bottompage", and more.
 %    \begin{macrocode}
 \def\coverpage#1{
   {
+%    \end{macrocode}
+%  Disable externalization for generating title page and bottom page, locally.
+%    \begin{macrocode}
     \tikzset{external/export=false}
+%    \end{macrocode}
+%  Set the \verb"parindent" to 0pt to avoid unwanted shift if indent is set.
+%    \begin{macrocode}
+    \setlength{\parindent}{0em}
+%    \end{macrocode}
+%   Check if it is in sidebar mode to make necessary shift for cover pages.
+%    \begin{macrocode}
     \ifdim\beamer@sidebarwidth=0pt %
       \usebeamertemplate*{#1}
     \else

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -126,13 +126,11 @@
 %
 %   Introduce the library from tcolorbox to make code blocks.
 %   \verb"listingsutf8" is used to receive UTF-8 input. 
-%   \verb"breakable" is used for potential codeblock breaking. (Not recommended)
 %   The global set on shield externalize will prevent tcolorbox from externalizing. 
 %    \begin{macrocode}
 \RequirePackage{tcolorbox}
 \tcbuselibrary{skins}
 \tcbuselibrary{listingsutf8}
-\tcbuselibrary{breakable}
 \tcbset{shield externalize}
 %    \end{macrocode}
 %
@@ -375,7 +373,6 @@
     #1,
   },
   enhanced,
-  breakable,
   sharp corners,
   top=0mm,
   bottom=0mm,
@@ -419,7 +416,6 @@
   },
   listing file=#3,
   enhanced,
-  breakable,
   sharp corners,
   top=0mm,
   bottom=0mm,

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/03/10 sjtubeamer inner theme v2.5.5]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/03/10 sjtubeamer inner theme v2.5.6]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -361,7 +361,7 @@
 %   Code block environment is made for presenting code in an obvious way.
 %   The first optional parameter is passed to listing, which mostly sets the language to highlight, see the \verb"listings" package for more details. 
 %   The second required parameter receives the title to make.
-%   ADVANCED TIP: For longer typeset, remove the \verb"frame" environment around the code input for occupying cross the pages. If you use \verb"lstlisting" environment directly, no numbering is preset so you need to set the number manually for this basic command.
+%   ADVANCED TIP: For longer typeset, use \verb"lstlisting" environment directly and remove the \verb"frame" environment around the code input for occupying cross the pages. No numbering is preset so you need to set the number manually for this basic command.
 %    \begin{macrocode}
 \newtcblisting{codeblock}[2][]{
   listing only,
@@ -403,7 +403,7 @@
 %   The first optional parameter is passed to listing.
 %   The second required parameter receives the title to make.
 %   The third required paramter receives the file to typeset.
-%   ADVANCED TIP: For longer typeset, remove the \verb"frame" environment around the code input for occupying cross the pages. If you use \verb"lstinputlisting" command directly, no numbering is preset so you need to set the number manually for this basic command.
+%   ADVANCED TIP: For longer typeset, use \verb"lstinputlisting" command directly and remove the \verb"frame" environment around the code input for occupying cross the pages. No numbering is preset so you need to set the number manually for this basic command.
 %    \begin{macrocode}
 \newtcbinputlisting{\codeblockinput}[3][]{
   listing only,

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -392,8 +392,9 @@
 % \begin{macro}{\highlightline}
 %    Highlight the current line with a light background. 
 %    It is useful for the codeblock environment with \verb"escapechar" option to insert the command for highlighting. For example, set the optional argument \verb"escapechar=|", and insert \verb"|\highlightline|" at the first position in the line you want to highlight.
+%    You could use overlay specification for this macro.
 %    \begin{macrocode}
-\providecommand{\highlightline}{\rlap{\color{structure!25}\rule[-\dp\strutbox]{\linewidth}{\baselineskip}}}
+\newcommand<>{\highlightline}{\only#1{\rlap{\color{structure!25}\rule[-\dp\strutbox]{\linewidth}{\baselineskip}}}}
 %    \end{macrocode}
 %    For better support in code environment, you should try out the \verb"highlightlines" in minted package, but performance drop is expected.
 % \end{macro}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -309,8 +309,9 @@
 %   Highlight the given text. Create a \verb"structure" color background block with white text.
 %   Receives one optional paramenter to specify the background color. If you want to modify the color of the text, use \verb"\color{}" command or \verb"\textcolor{}{}" command for your text.
 %   For a general use and better control, use \verb"\colorbox{}{}" from \verb"xcolor" directly.
+%   Overlay option can be specified as well.
 %    \begin{macrocode}
-\newcommand{\highlight}[2][structure]{\textcolor{white}{\colorbox{#1}{#2}}}
+\newcommand<>{\highlight}[2][structure]{\only#3{\textcolor{white}{\colorbox{#1}{#2}}}}
 %    \end{macrocode}
 %   Since \verb"structure" is globally available, we can use it to set the background color without introducing first.
 %   We decided to use a dark background rather than the traditional light highlight marker like color, since the former one is better for presentation highlighting and the later one is more like the overlay effect in \verb"beamer".

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/03/10 sjtubeamer outer theme v2.5.5]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/03/10 sjtubeamer outer theme v2.5.6]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/03/10 sjtubeamer parent theme v2.5.5]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/03/10 sjtubeamer parent theme v2.5.6]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/03/10 cover library for sjtubeamer v2.5.5]
+\ProvidesPackage{sjtucover}[2022/03/10 cover library for sjtubeamer v2.5.6]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -212,6 +212,7 @@
 %
 % \begin{macro}{\sjtubeamer@compatible}
 % For \TeX Live 2018 and even older, it is \emph{not} compatible to use the patterns.meta library for making user-defined patterns. And fading is not available for caching. Please consider \verb"\def\sjtubeamer@compatible{false}" to match the following condition checking. Remember to use \verb"\makeatletter" and \verb"\makeatother" in \LaTeX{}.
+% TODO: Get it into an option, not a macro. We have to consider the transmission model.
 %    \begin{macrocode}
 \def\sjtubeamer@compatible@false{false}
 %    \end{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/03/10 Visual Identity System library for sjtubeamer v2.5.5]
+\ProvidesPackage{sjtuvi}[2022/03/10 Visual Identity System library for sjtubeamer v2.5.6]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
本 PR 
- 修复 codeblock 环境的 `breakable` 将会导致使用 `columns` 另一列无法显示的问题，已经去除。
- 对 `\highlight` 和 `\highlightline` 添加 overlay option，可以采用可选的 `<#1>` 用于指示在哪一页显示。
- 对于 cover 将会强制 parindent 为 0 以避免偏移。https://github.com/sjtug/SJTUBeamer/pull/88/commits/a6e7bb8230585b52e1736623fd2b601098ff0936