### PR TITLE
fix: part page navigation bar

### DIFF
--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/03/10 sjtubeamer color theme v2.5.6]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/03/21 sjtubeamer color theme v2.5.7]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/03/10 sjtubeamer font theme v2.5.6]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/03/21 sjtubeamer font theme v2.5.7]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/03/10 sjtubeamer inner theme v2.5.6]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/03/21 sjtubeamer inner theme v2.5.7]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/03/10 sjtubeamer outer theme v2.5.6]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/03/21 sjtubeamer outer theme v2.5.7]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/03/10 sjtubeamer parent theme v2.5.6]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/03/21 sjtubeamer parent theme v2.5.7]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/03/10 cover library for sjtubeamer v2.5.6]
+\ProvidesPackage{sjtucover}[2022/03/21 cover library for sjtubeamer v2.5.7]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{cn}
 \DefineOption{cover}{lang}{en}
@@ -385,14 +385,14 @@
     \par\vskip4pt
     \usebeamerfont{part title}\insertpart\par
     \hbox to \textwidth{
-      \usebeamerfont{footline}%
-      \setbeamercolor{tempcolor}{fg=section in head/foot.fg}
-      \setbeamercolor{section in head/foot}{use=palette primary,
-        fg=palette primary.fg,bg=}
-      \hfill
-      \insertnavigation{0.4\textwidth}
-      \hspace*{1cm}
-      \setbeamercolor{section in head/foot}{fg=tempcolor.fg}
+      {
+        \usebeamerfont{footline}
+        \setbeamercolor{section in head/foot}{use=palette primary,
+          fg=palette primary.fg,bg=}
+        \let\navwidth\textwidth
+        \advance\navwidth by -32pt
+        \insertsectionnavigationhorizontal{\navwidth}{\hskip0pt plus1filll}{\hskip-.3cm}\hskip11pt
+      }
     }
   \end{beamercolorbox}
   \endgroup

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/03/10 Visual Identity System library for sjtubeamer v2.5.6]
+\ProvidesPackage{sjtuvi}[2022/03/21 Visual Identity System library for sjtubeamer v2.5.7]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/03/10 sjtubeamer color theme v2.5.6]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/03/21 sjtubeamer color theme v2.5.7]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/03/10 sjtubeamer font theme v2.5.6]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/03/21 sjtubeamer font theme v2.5.7]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/03/10 sjtubeamer inner theme v2.5.6]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/03/21 sjtubeamer inner theme v2.5.7]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/03/10 sjtubeamer outer theme v2.5.6]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/03/21 sjtubeamer outer theme v2.5.7]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/03/10 sjtubeamer parent theme v2.5.6]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/03/21 sjtubeamer parent theme v2.5.7]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -547,17 +547,18 @@
     \par\vskip4pt
     \usebeamerfont{part title}\insertpart\par
 %    \end{macrocode}
-%   Since navigation bar is packaged, to modify the color, you have to change the \verb"section in head/foot" beamer color. Here, the first move is to save the current color to a temporary variable. After the insertion, the previous color should be restored.
+%   Since navigation bar is packaged, to modify the color, you have to change the \verb"section in head/foot" beamer color. Here, use a group to make the temporary change. 
+%   Instead of using \verb"\insertnavigation" macro, use \verb"\insertsectionnavigationhorizontal" macro for a better control of long navigation bar.
 %    \begin{macrocode}
     \hbox to \textwidth{
-      \usebeamerfont{footline}%
-      \setbeamercolor{tempcolor}{fg=section in head/foot.fg}
-      \setbeamercolor{section in head/foot}{use=palette primary,
-        fg=palette primary.fg,bg=}
-      \hfill
-      \insertnavigation{0.4\textwidth}
-      \hspace*{1cm}
-      \setbeamercolor{section in head/foot}{fg=tempcolor.fg}
+      {
+        \usebeamerfont{footline}
+        \setbeamercolor{section in head/foot}{use=palette primary,
+          fg=palette primary.fg,bg=}
+        \let\navwidth\textwidth
+        \advance\navwidth by -32pt
+        \insertsectionnavigationhorizontal{\navwidth}{\hskip0pt plus1filll}{\hskip-.3cm}\hskip11pt
+      }
     }
   \end{beamercolorbox}
   \endgroup

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/03/10 cover library for sjtubeamer v2.5.6]
+\ProvidesPackage{sjtucover}[2022/03/21 cover library for sjtubeamer v2.5.7]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/03/10 Visual Identity System library for sjtubeamer v2.5.6]
+\ProvidesPackage{sjtuvi}[2022/03/21 Visual Identity System library for sjtubeamer v2.5.7]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
采用 `\insertsectionnavigationhorizontal` 宏而不是 `\insertnavigation` 来插入导航栏，防止溢出。

Before
<img width="615" alt="image" src="https://user-images.githubusercontent.com/61653082/159204125-8c3455d7-6e5a-4732-ba59-8f735bffc6a9.png">

After
<img width="614" alt="image" src="https://user-images.githubusercontent.com/61653082/159204079-ed1d6458-c4ec-4c56-a08a-aa086b7b8a55.png">
