### PR TITLE
contrib: shadedsection for sjtug theme

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -57,19 +57,19 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\\articleitem",
 		"body": "\\articleitem",
-		"description": "Start a bibliography item with an article icon, it is recommended to use inside bibliolist environment (or it will be not functional if the beamer template of bibliography item is not text).\nRemember the newblock will be created after this item so you should use \\newblock to split different categories in the order of author, title, location and notes.\n"
+		"description": "Start a bibliography item with an article icon, it is recommended to use inside bibliolist environment (or it will not be functional if the beamer template of bibliography item is not text).\nRemember the \\newblock will be created after this item so you should use \\newblock to split different categories in the order of author, title, location and notes.\n"
 	},
 	"bookitem": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\bookitem",
 		"body": "\\bookitem",
-		"description": "Start a bibliography item with an book icon, it is recommended to use inside bibliolist environment (or it will be not functional if the beamer template of bibliography item is not text).\nRemember the newblock will be created after this item so you should use \\newblock to split different categories in the order of author, title, location and notes.\n"
+		"description": "Start a bibliography item with an book icon, it is recommended to use inside bibliolist environment (or it will not be functional if the beamer template of bibliography item is not text).\nRemember the \\newblock will be created after this item so you should use \\newblock to split different categories in the order of author, title, location and notes.\n"
 	},
 	"onlineitem": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\onlineitem",
 		"body": "\\onlineitem",
-		"description": "Start a bibliography item with an online icon, it is recommended to use inside bibliolist environment (or it will be not functional if the beamer template of bibliography item is not text). \nRemember the newblock will be created after this item so you should use \\newblock to split different categories in the order of author, title, location and notes.\n"
+		"description": "Start a bibliography item with an online icon, it is recommended to use inside bibliolist environment (or it will not be functional if the beamer template of bibliography item is not text). \nRemember the \\newblock will be created after this item so you should use \\newblock to split different categories in the order of author, title, location and notes.\n"
 	},
 	"highlight": {
 		"scope": "doctex,tex,latex",

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -122,7 +122,7 @@
   \begin{thebibliography}{#1}
     \let\olditem\item%
     \def\item{\def\newblock{\beamer@newblock}\olditem}
-  \setbeamertemplate{bibliography item}[text]
+    \setbeamertemplate{bibliography item}[text]
 }{
   \end{thebibliography}
 }

--- a/contrib/sjtug/sjtubeamerthemesjtug.ltx
+++ b/contrib/sjtug/sjtubeamerthemesjtug.ltx
@@ -106,3 +106,19 @@
     \oldmakebottom
   }
 }
+% 新的数字节标题环境
+\newenvironment{shadedsection}{
+  \newcommand{\shadedfont}[2][1pt]{
+  % ##1 (optional): shadow distance
+  % ##2: the text needed to be shaded
+    \hbox{\rlap{\color{gray}\hskip##1##2}##2}
+  }
+  \setcounter{section}{-1}
+  \newcommand{\updatelogo}{
+    \logo{
+      \raise.3ex\hbox{\tiny\insertsection}\shadedfont{\arabic{section}}
+    }
+  }
+  \let\oldsection=\section
+  \renewcommand{\section}[1]{\oldsection{##1}\updatelogo}
+}{}

--- a/contrib/sjtug/sjtubeamerthemesjtug.ltx
+++ b/contrib/sjtug/sjtubeamerthemesjtug.ltx
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 % 设置文件元数据
-\ProvidesFile{sjtubeamerthemesjtug.ltx}[2022/03/30 SJTUG subtheme for SJTUBeamer]
+\ProvidesFile{sjtubeamerthemesjtug.ltx}[2022/04/27 SJTUG subtheme for SJTUBeamer]
 % 设置组织名称
 \institute[SJTU Linux User Group]{上海交通大学 Linux 用户组}
 % 设置徽标

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -422,7 +422,7 @@ fontupper=\sffamily,colupper=white}
 
 \section{表格}
 
-考虑到许多专业数据是直接存储在逗号分隔符（\texttt{.csv}）文件中的，便于数据内容的后续更改，用户可以采用 \texttt{pgfplotstable} 宏包从文件插入表格（该宏包只支持英文表格）。
+考虑到许多专业数据是直接存储在逗号分隔符（\texttt{.csv}）文件中的，便于数据内容的后续更改，用户可以采用 \texttt{pgfplotstable} 宏包从文件插入表格（中文表格需要使用 \hologo{XeLaTeX} 编译）。
 
 \beamerdemo[1]{step17.tex}
 

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -313,7 +313,7 @@
 %    The direct patch on \verb"\item" is hard since \verb"\bibitem" also depends on this command. As a matter of fact, the \verb"\item" itself cannot be cited and should not be numbered by the way otherwise user should use \verb"\bibitem" inside \verb"\thebibliography" environment directly.
 %    Set the beamer template of \verb"bibliography item" to \verb"text" locally to use the label of every item instead of the default icon outside the environment. This will also make the default behavior to make a bracket enumerate list.
 %    \begin{macrocode}
-  \setbeamertemplate{bibliography item}[text]
+    \setbeamertemplate{bibliography item}[text]
 }{
   \end{thebibliography}
 }

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -295,23 +295,23 @@
 %    \begin{macrocode}
 \newenvironment{bibliolist}[1]{
 %    \end{macrocode}
-%    Patch the \verb"\item" command in this environment, to redefine \verb"\newblock" and assign \verb"\newblock" after this command. The style will behave like \verb"\bibitem" but without the mandantory parameter for bib key.
+%    This environment will make use of the native \verb"thebibliography" environment redefined by \verb"beamer".
 %    \begin{macrocode}
   \begin{thebibliography}{#1}
 %    \end{macrocode}
-%     Save the old definition for item.
+%     Save the old definition for \verb"\item".
 %    \begin{macrocode}
     \let\olditem\item%
 %    \end{macrocode}
 %    Now define the item with new definition of \verb"\newblock" without interrupting the scan of next char for \verb"\item". Now, you could use \verb"\newblock" normally after \verb"\item" command with the initialized \verb"\newblock" state.
-%    This will not interrupt the definition of \verb"\bibitem" since the same definition on \verb"\newblock" has been made --- just define the thing the same time twice. Notice that the patch is NOT available for the regular \verb"thebibliography" command for compatibility reasons with other themes.
+%    This will not interrupt the definition of \verb"\bibitem" since the same definition on \verb"\newblock" has been made --- just define the same thing twice. Notice that the patch is NOT available for the regular \verb"thebibliography" command for compatibility reasons with other themes.
 %    \begin{macrocode}
     \def\item{\def\newblock{\beamer@newblock}\olditem}
 %    \end{macrocode}
-%    User should insert items by \verb"\articleitem", \verb"\bookitem", \verb"\onlineitem" inside THIS environment, otherwise, the user should insert \verb"\newblock" after \verb"\item" manually, which breaks the use of \verb"\newblock" and not recommended with the only use of migration from \textsc{SJTUThesis} with the same style. Or not to use \verb"\newblock" for \verb"\item" at all.
-%    The commands like \verb"\articleitem" do not accept the optional parameter for a label since the first part of this command name has already indicates the label of this item. The command like \verb"\item" accepts the optional parameter for the label and will override the potential numeric numbering (you have to load \verb"biblatex" in the preamble or specify the \verb"bibliography item" beamer template to \verb"text" inside this environment) for this item without a bracket surrounding. The behavior is the same as \textsc{SJTUThesis}.
+%    User should insert items by \verb"\articleitem", \verb"\bookitem", \verb"\onlineitem" inside THIS environment, otherwise, the user should insert \verb"\newblock" after \verb"\item" manually, which breaks the use of \verb"\newblock" and not recommended. Or not to use \verb"\newblock" for \verb"\item" at all for migration from \textsc{SJTUThesis} with the same style.
+%    The commands like \verb"\articleitem" do not accept the optional parameter for a label since the first part of this command name has already indicates the label of this item. The command like \verb"\item" accepts the optional parameter for the label and will override the numeric numbering for this item without a bracket surrounding. The behavior is the same as \textsc{SJTUThesis}.
 %    The direct patch on \verb"\item" is hard since \verb"\bibitem" also depends on this command. As a matter of fact, the \verb"\item" itself cannot be cited and should not be numbered by the way otherwise user should use \verb"\bibitem" inside \verb"\thebibliography" environment directly.
-%    Set the beamer template of \verb"bibliography item" to \verb"text" locally to use the label of every item instead of the default icon outside the environment. This will also make the default behavior to make an bracket enumerate list.
+%    Set the beamer template of \verb"bibliography item" to \verb"text" locally to use the label of every item instead of the default icon outside the environment. This will also make the default behavior to make a bracket enumerate list.
 %    \begin{macrocode}
   \setbeamertemplate{bibliography item}[text]
 }{
@@ -320,12 +320,12 @@
 %    \end{macrocode}
 %    This environment syncs with \textsc{SJTUThesis}. It is used to generate the customized look of bibliography list without the processing from \textsc{Bib}\TeX{} or \verb"biblatex", which could bring performance improvement.
 %    You can specify the style of the icon by \verb"\setbeamertemplate{bibliography item}[book]" or other predefined template provided by \verb"beamer" class like \verb"online", \verb"triangle", \verb"text" (for square bracket enumeration).
-%    And such the setting should be done INSIDE the environment since \verb"beamer" will override the user setting on this template to text style at the begining of \verb"document" environment if it loads \verb"biblatex".
+%    And such the setting should be done INSIDE the environment and \verb"thebibliography" since \verb"beamer" will override the user setting on this template to text style at the begining of \verb"document" environment if it loads \verb"biblatex".
 % \end{macro}
 %
 %  \begin{macro}{\articleitem}
-%    Start a bibliography item with an article icon, it is recommended to use inside \verb"bibliolist" environment (or it will be not functional if the beamer template of \verb"bibliography item" is not \verb"text").
-%    Remember the newblock will be created after this item so you should use \verb"\newblock" to split different categories in the order of author, title, location and notes.
+%    Start a bibliography item with an article icon, it is recommended to use inside \verb"bibliolist" environment (or it will not be functional if the beamer template of \verb"bibliography item" is not \verb"text").
+%    Remember the \verb"\newblock" will be created after this item so you should use \verb"\newblock" to split different categories in the order of author, title, location and notes.
 %    \begin{macrocode}
 \newcommand{\articleitem}{%
   \item[{\setbeamertemplate{bibliography item}[article]\usebeamertemplate{bibliography item}}]%
@@ -335,8 +335,8 @@
 %  \end{macro}
 %
 %  \begin{macro}{\bookitem}
-%    Start a bibliography item with an book icon, it is recommended to use inside \verb"bibliolist" environment (or it will be not functional if the beamer template of \verb"bibliography item" is not \verb"text").
-%    Remember the newblock will be created after this item so you should use \verb"\newblock" to split different categories in the order of author, title, location and notes.
+%    Start a bibliography item with an book icon, it is recommended to use inside \verb"bibliolist" environment (or it will not be functional if the beamer template of \verb"bibliography item" is not \verb"text").
+%    Remember the \verb"\newblock" will be created after this item so you should use \verb"\newblock" to split different categories in the order of author, title, location and notes.
 %    \begin{macrocode}
 \newcommand{\bookitem}{%
   \item[{\setbeamertemplate{bibliography item}[book]\usebeamertemplate{bibliography item}}]%
@@ -346,8 +346,8 @@
 %  \end{macro}
 %
 %  \begin{macro}{\onlineitem}
-%    Start a bibliography item with an online icon, it is recommended to use inside \verb"bibliolist" environment (or it will be not functional if the beamer template of \verb"bibliography item" is not \verb"text"). 
-%    Remember the newblock will be created after this item so you should use \verb"\newblock" to split different categories in the order of author, title, location and notes.
+%    Start a bibliography item with an online icon, it is recommended to use inside \verb"bibliolist" environment (or it will not be functional if the beamer template of \verb"bibliography item" is not \verb"text"). 
+%    Remember the \verb"\newblock" will be created after this item so you should use \verb"\newblock" to split different categories in the order of author, title, location and notes.
 %    \begin{macrocode}
 \newcommand{\onlineitem}{%
   \item[{\setbeamertemplate{bibliography item}[online]\usebeamertemplate{bibliography item}}]%

--- a/src/source/beamerthemesjtubeamer.ins
+++ b/src/source/beamerthemesjtubeamer.ins
@@ -82,11 +82,11 @@ see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 \Msg{* To finish the installation you have to move the following  *}
 \Msg{* files into a directory searched by TeX:                    *}
 \Msg{*                                                            *}
-\Msg{*     beamerthemesjtubeamermin.sty                           *}
-\Msg{*     beamerinnerthemesjtubeamermin.sty                      *}
-\Msg{*     beamerouterthemesjtubeamermin.sty                      *}
-\Msg{*     beamerfontthemesjtubeamermin.sty                       *}
-\Msg{*     beamercolorthemesjtubeamermin.sty                      *}
+\Msg{*     beamerthemesjtubeamer.sty                              *}
+\Msg{*     beamerinnerthemesjtubeamer.sty                         *}
+\Msg{*     beamerouterthemesjtubeamer.sty                         *}
+\Msg{*     beamerfontthemesjtubeamer.sty                          *}
+\Msg{*     beamercolorthemesjtubeamer.sty                         *}
 \Msg{*     sjtucover.sty                                          *}
 \Msg{*     sjtuvi.sty                                             *}
 \Msg{*     vi/                                                    *}

--- a/src/support/tutorial/step16+-.tex
+++ b/src/support/tutorial/step16+-.tex
@@ -12,7 +12,7 @@
   \begin{bibliolist}{00}
     \bookitem \textsc{Author}.
     \newblock Title[M].
-    \newblock\newblock 2nd ed. Location: Press. 2004.
+    \newblock 2nd ed. Location: Press. 2004.
   \end{bibliolist}
 \end{frame}
 \end{document}


### PR DESCRIPTION
对 SJTUG 子主题添加 `shadedsection` 环境封装带阴影编号的 logo 图标。

更新一些文档内容。


PS: 最近 LaTeX Workshop 自带的 PDF 阅读器对透明度的实现可能有 BUG，使用其他软件打开 PDF 背景图片是较淡的正常透明度。