### PR TITLE
fix: remove \nointerlineskip

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -53,24 +53,6 @@
 		"body": "\n\\begin{bibliolist}{$1}\n\t$2\n\\end{bibliolist}\n",
 		"description": "Create a bibliography list manually with \\item patched for \\newblock. \nYou can just use \\item without \\newblock command, or you could use \\newblock with \\articleitem, \\bookitem, \\onlineitem.\nThe mandantory parameter (usually 00) indicates the widest label among items, if you want to indicate the item label seperately.\n"
 	},
-	"articleitem": {
-		"scope": "doctex,tex,latex",
-		"prefix": "\\articleitem",
-		"body": "\\articleitem",
-		"description": "Start a bibliography item with an article icon, it is recommended to use inside bibliolist environment (or it will not be functional if the beamer template of bibliography item is not text).\nRemember the \\newblock will be created after this item so you should use \\newblock to split different categories in the order of author, title, location and notes.\n"
-	},
-	"bookitem": {
-		"scope": "doctex,tex,latex",
-		"prefix": "\\bookitem",
-		"body": "\\bookitem",
-		"description": "Start a bibliography item with an book icon, it is recommended to use inside bibliolist environment (or it will not be functional if the beamer template of bibliography item is not text).\nRemember the \\newblock will be created after this item so you should use \\newblock to split different categories in the order of author, title, location and notes.\n"
-	},
-	"onlineitem": {
-		"scope": "doctex,tex,latex",
-		"prefix": "\\onlineitem",
-		"body": "\\onlineitem",
-		"description": "Start a bibliography item with an online icon, it is recommended to use inside bibliolist environment (or it will not be functional if the beamer template of bibliography item is not text). \nRemember the \\newblock will be created after this item so you should use \\newblock to split different categories in the order of author, title, location and notes.\n"
-	},
 	"highlight": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\highlight",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}
@@ -123,20 +123,20 @@
     \let\olditem\item%
     \def\item{\def\newblock{\beamer@newblock}\olditem}
     \setbeamertemplate{bibliography item}[text]
+    \newcommand{\articleitem}{%
+      \item[{\setbeamertemplate{bibliography item}[article]\usebeamertemplate{bibliography item}}]%
+      \newblock%
+    }
+    \newcommand{\bookitem}{%
+      \item[{\setbeamertemplate{bibliography item}[book]\usebeamertemplate{bibliography item}}]%
+      \newblock%
+    }
+    \newcommand{\onlineitem}{%
+      \item[{\setbeamertemplate{bibliography item}[online]\usebeamertemplate{bibliography item}}]%
+      \newblock%
+    }
 }{
   \end{thebibliography}
-}
-\newcommand{\articleitem}{%
-  \item[{\setbeamertemplate{bibliography item}[article]\usebeamertemplate{bibliography item}}]%
-  \def\newblock{\beamer@newblock}\newblock%
-}
-\newcommand{\bookitem}{%
-  \item[{\setbeamertemplate{bibliography item}[book]\usebeamertemplate{bibliography item}}]%
-  \def\newblock{\beamer@newblock}\newblock%
-}
-\newcommand{\onlineitem}{%
-  \item[{\setbeamertemplate{bibliography item}[online]\usebeamertemplate{bibliography item}}]%
-  \def\newblock{\beamer@newblock}\newblock%
 }
 \if\EqualOption{inner}{cover}{min}\else
   \setbeamertemplate{blocks}[rounded]

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/contrib/sjtug/sjtubeamerthemesjtug.ltx
+++ b/contrib/sjtug/sjtubeamerthemesjtug.ltx
@@ -41,6 +41,7 @@
 \fi
 % 制作自定标题页
 \defbeamertemplate*{title page}{sjtug}[1][]{
+  \vbox{}
   \usebeamercolor{palette primary}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)

--- a/contrib/sjtug/sjtubeamerthemesjtug.ltx
+++ b/contrib/sjtug/sjtubeamerthemesjtug.ltx
@@ -41,10 +41,7 @@
 \fi
 % 制作自定标题页
 \defbeamertemplate*{title page}{sjtug}[1][]{
-  \nointerlineskip
-  \vbox{}
   \usebeamercolor{palette primary}
-  \def\sjtubeamer@logocolor{palette primary.fg}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
     rectangle (1*\the\paperwidth, 0.3*\the\paperheight);

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/04/21 v2.6.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/05 v2.6.2 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}
@@ -41,8 +41,6 @@
 }
 \defbeamertemplate*{title page}{maxplus}[1][]
 {
-  \nointerlineskip%
-  \vbox{}
   \vfill
   \begingroup
   \usebeamercolor{palette primary}%
@@ -80,8 +78,6 @@
 }
 \defbeamertemplate*{title page}{max}[1][]
 {
-  \nointerlineskip
-  \vbox{}
   \usebeamercolor{palette primary}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
@@ -248,8 +244,6 @@
   right color=transparent!100]
 \defbeamertemplate*{bottom page}{maxplus}[1][]
 {
-  \nointerlineskip
-  \vbox{}
   \begin{tikzpicture}[overlay]
     \usebeamercolor{palette primary}
     \fill[palette primary.bg] (-0.2\paperwidth,-\paperheight)
@@ -282,8 +276,6 @@
 }
 \defbeamertemplate*{bottom page}{max}[1][]
 {
-  \nointerlineskip
-  \vbox{}
   \usebeamercolor{palette primary}
   \usebeamercolor{structure}
   \begin{beamercolorbox}[sep=0pt]{empty}
@@ -417,8 +409,6 @@
 }
 \defbeamertemplate*{sectioning page}{maxplus}[1]
 {
-  \nointerlineskip
-  \vbox{}
   \def\sjtubeamer@cover@sectype{#1}
   \usebeamercolor{#1 title}
   \begin{tikzpicture}[overlay]

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -41,6 +41,7 @@
 }
 \defbeamertemplate*{title page}{maxplus}[1][]
 {
+  \vbox{}
   \vfill
   \begingroup
   \usebeamercolor{palette primary}%
@@ -78,6 +79,7 @@
 }
 \defbeamertemplate*{title page}{max}[1][]
 {
+  \vbox{}
   \usebeamercolor{palette primary}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
@@ -244,6 +246,7 @@
   right color=transparent!100]
 \defbeamertemplate*{bottom page}{maxplus}[1][]
 {
+  \vbox{}
   \begin{tikzpicture}[overlay]
     \usebeamercolor{palette primary}
     \fill[palette primary.bg] (-0.2\paperwidth,-\paperheight)
@@ -276,6 +279,7 @@
 }
 \defbeamertemplate*{bottom page}{max}[1][]
 {
+  \vbox{}
   \usebeamercolor{palette primary}
   \usebeamercolor{structure}
   \begin{beamercolorbox}[sep=0pt]{empty}
@@ -409,6 +413,7 @@
 }
 \defbeamertemplate*{sectioning page}{maxplus}[1]
 {
+  \vbox{}
   \def\sjtubeamer@cover@sectype{#1}
   \usebeamercolor{#1 title}
   \begin{tikzpicture}[overlay]

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/04/21 v2.6.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/05 v2.6.2 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -306,11 +306,11 @@ fontupper=\sffamily,colupper=white}
 
 \chapter{播放}
 
-制作的演示文稿推荐使用 Adobe Acrobat 播放，浏览器内置的阅读器不支持一些额外功能。
+制作的演示文稿推荐使用 Adobe Acrobat 播放，浏览器内置的阅读器不支持一些额外功能。在使用 \texttt{\textbackslash{}note} 添加幻灯片备注时，推荐使用 Pympress 软件。
 
 \section{Adobe Acrobat}
 
-在 Adobe Acrobat Pro（或免费版本的 Adobe Acrobat Reader）打开演示文稿，在“视图”选单中选择“全屏模式”即可播放。
+在 Adobe Acrobat Pro（或免费版本的 \href{https://www.adobe.com/cn/acrobat/pdf-reader.html}{Adobe Acrobat Reader}）打开演示文稿，在“视图”选单中选择“全屏模式”即可播放。
 
 \begin{figure}[h]
   \centering
@@ -331,6 +331,15 @@ fontupper=\sffamily,colupper=white}
     \end{figure}
   \item[\faInternetExplorer] Edge 浏览器需要调整为“适应宽度”\fbox{\faArrowsAltH}，并使用 \fbox{\sffamily PageDown} 翻页。尽量不要使用该播放方法。
 \end{enumerate}
+
+\section{Pympress}
+
+\href{https://github.com/Cimbali/pympress}{Pympress} 是一个类似于 PowerPoint
+演示者视图的阅读器，在导言区添加
+\begin{verbatim}
+ \setbeameroption{show notes on second screen}
+\end{verbatim}
+以展示备注幻灯片（幻灯片内使用 \texttt{\textbackslash{}note} 标记备注内容）于每页右侧。使用该软件以自动地识别备注区域展示在演示者屏幕上。
 
 \part{进阶操作}
 

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -412,7 +412,7 @@ fontupper=\sffamily,colupper=white}
 \begin{commentlist}
   \item \LaTeX{} 本身提供了 \texttt{thebibliography} 环境，环境的强制参数用于指定排版最长的标签（这里是两位数占位符），配套 \texttt{\textbackslash{}bibitem[标签]\{主键\}}，在 \texttt{beamer} 中需要辅以 \texttt{\textbackslash{}newblock} 来分隔作者、文章标题、书目与其他内容。这里的主键可以在正文中引用。
   \item 在 \texttt{beamer} 中可以通过设定 \texttt{bibliography item} 模板为对应预设来更改图标，这里是 \texttt{text} 预设用于排印编号。也可以改为文章图标 \texttt{article}，图书图标 \texttt{book} 或网络图标 \texttt{online} 等。
-  \item 为了与 \textsc{SJTUThesis} 兼容，引入 \texttt{bibliolist} 环境$^*$以避免使用 \texttt{\textbackslash{}bibitem} 命令，并添加对应的 \texttt{\textbackslash{}articleitem}, \texttt{\textbackslash{}bookitem}, \texttt{\textbackslash{}onlineitem} 用于切换不同的图标$^*$，并保持与 \texttt{\textbackslash{}bibitem} 相同的用法。
+  \item 引入 \texttt{bibliolist} 环境$^*$以避免使用 \texttt{\textbackslash{}bibitem} 命令，并添加对应的 \texttt{\textbackslash{}articleitem}, \texttt{\textbackslash{}bookitem}, \texttt{\textbackslash{}onlineitem} 用于切换不同的图标$^*$，并保持与 \texttt{\textbackslash{}bibitem} 相同的用法（除了不能设定引用标签）。
   \item 在 \texttt{bibliolist} 环境中也可以直接使用 \texttt{\textbackslash{}item} 以不使用 \texttt{\textbackslash{}newblock} 来分割条目中的不同部分，正如 \textsc{SJTUThesis} 所做的那样。但请不要与上一条中的图标命令混用。
 \end{commentlist}
 

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -314,6 +314,24 @@
 %    Set the beamer template of \verb"bibliography item" to \verb"text" locally to use the label of every item instead of the default icon outside the environment. This will also make the default behavior to make a bracket enumerate list.
 %    \begin{macrocode}
     \setbeamertemplate{bibliography item}[text]
+%    \end{macrocode}
+%   Define command for creating icon bib item: \verb"article", \verb"bookitem", \verb"onlineitem". These command indicates that the user will use \verb"\newblock" for seperating fields.
+%    \begin{macrocode}
+    \newcommand{\articleitem}{%
+      \item[{\setbeamertemplate{bibliography item}[article]\usebeamertemplate{bibliography item}}]%
+      \newblock%
+    }
+    \newcommand{\bookitem}{%
+      \item[{\setbeamertemplate{bibliography item}[book]\usebeamertemplate{bibliography item}}]%
+      \newblock%
+    }
+    \newcommand{\onlineitem}{%
+      \item[{\setbeamertemplate{bibliography item}[online]\usebeamertemplate{bibliography item}}]%
+      \newblock%
+    }
+%    \end{macrocode}
+%   Close the \verb"bibliolist" environment.
+%    \begin{macrocode}
 }{
   \end{thebibliography}
 }
@@ -323,38 +341,6 @@
 %    And such the setting should be done INSIDE the environment and \verb"thebibliography" since \verb"beamer" will override the user setting on this template to text style at the begining of \verb"document" environment if it loads \verb"biblatex".
 % \end{macro}
 %
-%  \begin{macro}{\articleitem}
-%    Start a bibliography item with an article icon, it is recommended to use inside \verb"bibliolist" environment (or it will not be functional if the beamer template of \verb"bibliography item" is not \verb"text").
-%    Remember the \verb"\newblock" will be created after this item so you should use \verb"\newblock" to split different categories in the order of author, title, location and notes.
-%    \begin{macrocode}
-\newcommand{\articleitem}{%
-  \item[{\setbeamertemplate{bibliography item}[article]\usebeamertemplate{bibliography item}}]%
-  \def\newblock{\beamer@newblock}\newblock%
-}
-%    \end{macrocode}
-%  \end{macro}
-%
-%  \begin{macro}{\bookitem}
-%    Start a bibliography item with an book icon, it is recommended to use inside \verb"bibliolist" environment (or it will not be functional if the beamer template of \verb"bibliography item" is not \verb"text").
-%    Remember the \verb"\newblock" will be created after this item so you should use \verb"\newblock" to split different categories in the order of author, title, location and notes.
-%    \begin{macrocode}
-\newcommand{\bookitem}{%
-  \item[{\setbeamertemplate{bibliography item}[book]\usebeamertemplate{bibliography item}}]%
-  \def\newblock{\beamer@newblock}\newblock%
-}
-%    \end{macrocode}
-%  \end{macro}
-%
-%  \begin{macro}{\onlineitem}
-%    Start a bibliography item with an online icon, it is recommended to use inside \verb"bibliolist" environment (or it will not be functional if the beamer template of \verb"bibliography item" is not \verb"text"). 
-%    Remember the \verb"\newblock" will be created after this item so you should use \verb"\newblock" to split different categories in the order of author, title, location and notes.
-%    \begin{macrocode}
-\newcommand{\onlineitem}{%
-  \item[{\setbeamertemplate{bibliography item}[online]\usebeamertemplate{bibliography item}}]%
-  \def\newblock{\beamer@newblock}\newblock%
-}
-%    \end{macrocode}
-%  \end{macro}
 %
 % \subsubsection{Block Environments}
 %

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/04/21 v2.6.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/05 v2.6.2 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -99,7 +99,6 @@
 %<*maxplus>
 \defbeamertemplate*{title page}{maxplus}[1][]
 {
-  \nointerlineskip%
   \vbox{}
   \vfill
   \begingroup
@@ -144,7 +143,6 @@
 %<*max>
 \defbeamertemplate*{title page}{max}[1][]
 {
-  \nointerlineskip
   \vbox{}
   \usebeamercolor{palette primary}
   \begin{tikzpicture}[overlay]
@@ -371,7 +369,6 @@
   right color=transparent!100]
 \defbeamertemplate*{bottom page}{maxplus}[1][]
 {
-  \nointerlineskip
   \vbox{}
   \begin{tikzpicture}[overlay]
     \usebeamercolor{palette primary}
@@ -411,7 +408,6 @@
 %<*max>
 \defbeamertemplate*{bottom page}{max}[1][]
 {
-  \nointerlineskip
   \vbox{}
   \usebeamercolor{palette primary}
   \usebeamercolor{structure}
@@ -634,7 +630,6 @@
 }
 \defbeamertemplate*{sectioning page}{maxplus}[1]
 {
-  \nointerlineskip
   \vbox{}
   \def\sjtubeamer@cover@sectype{#1}
   \usebeamercolor{#1 title}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -99,6 +99,8 @@
 %<*maxplus>
 \defbeamertemplate*{title page}{maxplus}[1][]
 {
+  \nointerlineskip%
+  \vbox{}
   \vfill
   \begingroup
   \usebeamercolor{palette primary}% 
@@ -142,6 +144,8 @@
 %<*max>
 \defbeamertemplate*{title page}{max}[1][]
 {
+  \nointerlineskip
+  \vbox{}
   \usebeamercolor{palette primary}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
@@ -367,6 +371,8 @@
   right color=transparent!100]
 \defbeamertemplate*{bottom page}{maxplus}[1][]
 {
+  \nointerlineskip
+  \vbox{}
   \begin{tikzpicture}[overlay]
     \usebeamercolor{palette primary}
     \fill[palette primary.bg] (-0.2\paperwidth,-\paperheight)
@@ -405,6 +411,8 @@
 %<*max>
 \defbeamertemplate*{bottom page}{max}[1][]
 {
+  \nointerlineskip
+  \vbox{}
   \usebeamercolor{palette primary}
   \usebeamercolor{structure}
   \begin{beamercolorbox}[sep=0pt]{empty}
@@ -626,6 +634,8 @@
 }
 \defbeamertemplate*{sectioning page}{maxplus}[1]
 {
+  \nointerlineskip
+  \vbox{}
   \def\sjtubeamer@cover@sectype{#1}
   \usebeamercolor{#1 title}
   \begin{tikzpicture}[overlay]

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -99,8 +99,6 @@
 %<*maxplus>
 \defbeamertemplate*{title page}{maxplus}[1][]
 {
-  \nointerlineskip%
-  \vbox{}
   \vfill
   \begingroup
   \usebeamercolor{palette primary}% 
@@ -144,8 +142,6 @@
 %<*max>
 \defbeamertemplate*{title page}{max}[1][]
 {
-  \nointerlineskip
-  \vbox{}
   \usebeamercolor{palette primary}
   \begin{tikzpicture}[overlay]
     \fill [palette primary.bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
@@ -371,8 +367,6 @@
   right color=transparent!100]
 \defbeamertemplate*{bottom page}{maxplus}[1][]
 {
-  \nointerlineskip
-  \vbox{}
   \begin{tikzpicture}[overlay]
     \usebeamercolor{palette primary}
     \fill[palette primary.bg] (-0.2\paperwidth,-\paperheight)
@@ -411,8 +405,6 @@
 %<*max>
 \defbeamertemplate*{bottom page}{max}[1][]
 {
-  \nointerlineskip
-  \vbox{}
   \usebeamercolor{palette primary}
   \usebeamercolor{structure}
   \begin{beamercolorbox}[sep=0pt]{empty}
@@ -634,8 +626,6 @@
 }
 \defbeamertemplate*{sectioning page}{maxplus}[1]
 {
-  \nointerlineskip
-  \vbox{}
   \def\sjtubeamer@cover@sectype{#1}
   \usebeamercolor{#1 title}
   \begin{tikzpicture}[overlay]

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/04/21 v2.6.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/05 v2.6.2 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/04/21 v2.6.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/05 v2.6.2 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
`\nointerlineskip` 会与 `beamer` 的 `\lecture{}{}` 与 `\includeonlylecture{}`冲突，需要移除封面页这样的代码：
```latex
% \nointerlineskip
\vbox{}
```
由于 `\nointerlineskip` 只会移除下一个盒子两端的间距，这两行代码或许会消除小间距，但是视觉区别不大。

似乎当时引入的时候只是为了消除 `beamercolorbox` 的间距，现在不需要了，#28 已经重构了该部分代码

https://github.com/sjtug/SJTUBeamer/blob/5001d991c06e647c7fc9165baa506d0d6fb1bf5c/beamerthemesjtubeamer.sty#L44-L45

杂项：
- `\articleitem`, `\bookitem`, `\onlineitem` 现在只可以在 `bibliolist` 中使用。
- 在文档中推荐 [pympress](https://github.com/Cimbali/pympress) 阅读器。