### PR TITLE
fix: itemmargin

### DIFF
--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -118,6 +118,10 @@
   \makepart
 }
 \useinnertheme{circles}
+\setlength\leftmargini{1.4em}
+\setlength\leftmarginii{1.4em}
+\setlength\leftmarginiii{1.4em}
+\setbeamersize{description width=0.24cm}
 \newenvironment{bibliolist}[1]{
   \begin{thebibliography}{#1}
     \let\olditem\item%

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/07 v2.7.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/09 v2.7.1 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/07 v2.7.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/09 v2.7.1 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -288,6 +288,14 @@
 \useinnertheme{circles}
 %    \end{macrocode}
 %
+%  Patch beamer on \verb"itemize",\verb"enumerate",\verb"description" on the left margin.
+%    \begin{macrocode}
+\setlength\leftmargini{1.4em}
+\setlength\leftmarginii{1.4em}
+\setlength\leftmarginiii{1.4em}
+\setbeamersize{description width=0.24cm}
+%    \end{macrocode}
+%
 % \begin{macro}{bibliolist}
 %    Create a bibliography list manually with \verb"\item" patched for \verb"\newblock". 
 %    You can just use \verb"\item" without \verb"\newblock" command, or you could use \verb"\newblock" with \verb"\articleitem", \verb"\bookitem", \verb"\onlineitem".

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/07 v2.7.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/07 v2.7.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/09 v2.7.1 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/07 v2.7.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/09 v2.7.1 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
参照 [原样式文件](https://github.com/sjtug/sjtulib-latex-talk/blob/68e336580ac2126aaaeffba3efd61c6f9402bbf7/beamerthemesjtug.sty#L23-L26) 修复 beamer 默认设置下列表环境边距过大的问题。

|Before|After|
|---|---|
|<img width="243" alt="image" src="https://user-images.githubusercontent.com/61653082/167334226-db89b2f7-5c6c-49a2-81bd-6e082cbbbce2.png">|<img width="199" alt="image" src="https://user-images.githubusercontent.com/61653082/167334199-7fe84c6d-2893-40d0-95de-d4f5fa047bb5.png">|