### PR TITLE
style: reduce frametitle height

### DIFF
--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -95,6 +95,9 @@
 \if\EqualOption{outer}{nav}{default}
   \setbeamercolor{frametitle}{use=palette primary,
     bg=palette primary.bg,fg=palette primary.fg}
+  \AtBeginDocument{
+    \setbeamertemplate{frametitle}[sjtubeamer][leftskip=0cm,sep=0.3cm]
+  }
 \else\if\EqualOption{outer}{nav}{infolines}
   \setbeamercolor{author in head/foot}{use=structure,fg=white,bg=structure}
   \setbeamercolor{title in head/foot}{use=structure,fg=structure,bg=structure!10}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -78,6 +78,11 @@
       \end{beamercolorbox}%
     }
   }
+  \if\EqualOption{outer}{nav}{default}
+    \AtBeginDocument{
+      \setbeamertemplate{frametitle}[sjtubeamer][leftskip=0cm,sep=0.3cm]
+    }
+  \fi
 \fi
 \if\EqualOption{outer}{nav}{miniframes}
   \useoutertheme[footline=institutetitle]{miniframes}
@@ -95,9 +100,6 @@
 \if\EqualOption{outer}{nav}{default}
   \setbeamercolor{frametitle}{use=palette primary,
     bg=palette primary.bg,fg=palette primary.fg}
-  \AtBeginDocument{
-    \setbeamertemplate{frametitle}[sjtubeamer][leftskip=0cm,sep=0.3cm]
-  }
 \else\if\EqualOption{outer}{nav}{infolines}
   \setbeamercolor{author in head/foot}{use=structure,fg=white,bg=structure}
   \setbeamercolor{title in head/foot}{use=structure,fg=structure,bg=structure!10}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}
@@ -40,18 +40,18 @@
 \beamer@compresstrue
 \if\EqualOption{outer}{logopos}{topright}
   \AtBeginDocument{
-    \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+    \defbeamertemplate*{frametitle}{sjtubeamer}[1][]
     {%
     \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
       \@tempdima=\textwidth%
       \advance\@tempdima by\beamer@leftmargin%
       \advance\@tempdima by\beamer@rightmargin%
-      \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+      \begin{beamercolorbox}[sep=0.15cm,leftskip=0.15cm,#1,wd=\the\@tempdima]{frametitle}
         \begingroup
         \usebeamerfont{frametitle}
         \vbox{}
         \ifx\insertframesubtitle\@empty\vskip-2pt%
-        \else\vskip-1ex\fi%
+        \else\vskip-5pt\fi%
         \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
         \strut\insertframetitle\strut\par%
         {%
@@ -68,12 +68,12 @@
         \endgroup%
         \raggedleft%
         \begingroup
-        \ifx\insertframesubtitle\@empty\vskip-2.5ex%
-        \else\vskip-3.5ex\fi%
+        \ifx\insertframesubtitle\@empty\vskip-2.3ex%
+        \else\vskip-3.0ex\fi%
         \resizebox{!}{0.7cm}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{5pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
-        \else\vskip0.5ex\fi%
+        \else\vskip0.6ex\fi%
         \if@tempswa\else\vskip-.3cm\fi%
       \end{beamercolorbox}%
     }

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/09 v2.7.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/10 v2.7.2 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/09 v2.7.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/10 v2.7.2 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -421,7 +421,7 @@ fontupper=\sffamily,colupper=white}
 \begin{commentlist}
   \item \LaTeX{} 本身提供了 \texttt{thebibliography} 环境，环境的强制参数用于指定排版最长的标签（这里是两位数占位符），配套 \texttt{\textbackslash{}bibitem[标签]\{主键\}}，在 \texttt{beamer} 中需要辅以 \texttt{\textbackslash{}newblock} 来分隔作者、文章标题、书目与其他内容。这里的主键可以在正文中引用。
   \item 在 \texttt{beamer} 中可以通过设定 \texttt{bibliography item} 模板为对应预设来更改图标，这里是 \texttt{text} 预设用于排印编号。也可以改为文章图标 \texttt{article}，图书图标 \texttt{book} 或网络图标 \texttt{online} 等。
-  \item 引入 \texttt{bibliolist} 环境$^*$以避免使用 \texttt{\textbackslash{}bibitem} 命令，并添加对应的 \texttt{\textbackslash{}articleitem}, \texttt{\textbackslash{}bookitem}, \texttt{\textbackslash{}onlineitem} 用于切换不同的图标$^*$，并保持与 \texttt{\textbackslash{}bibitem} 相同的用法（除了不能设定引用标签）。
+  \item 引入 \texttt{bibliolist} 环境$^*$以避免使用 \texttt{\textbackslash{}bibitem} 命令，对于每一条引用添加对应的 \texttt{\textbackslash{}articleitem}, \texttt{\textbackslash{}bookitem}, \texttt{\textbackslash{}onlineitem} 用于切换不同的图标$^*$，并保持与 \texttt{\textbackslash{}bibitem} 相同的用法（除了不能设定引用标签）。
   \item 在 \texttt{bibliolist} 环境中也可以直接使用 \texttt{\textbackslash{}item} 以不使用 \texttt{\textbackslash{}newblock} 来分割条目中的不同部分，正如 \textsc{SJTUThesis} 所做的那样。但请不要与上一条中的图标命令混用。
 \end{commentlist}
 

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -77,18 +77,18 @@
 %    \begin{macrocode}
 \if\EqualOption{outer}{logopos}{topright}
   \AtBeginDocument{
-    \defbeamertemplate*{frametitle}{sjtubeamer}[1][left]
+    \defbeamertemplate*{frametitle}{sjtubeamer}[1][]
     {%
     \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
       \@tempdima=\textwidth%
       \advance\@tempdima by\beamer@leftmargin%
       \advance\@tempdima by\beamer@rightmargin%
-      \begin{beamercolorbox}[sep=0.3cm,#1,wd=\the\@tempdima]{frametitle}
+      \begin{beamercolorbox}[sep=0.15cm,leftskip=0.15cm,#1,wd=\the\@tempdima]{frametitle}
         \begingroup
         \usebeamerfont{frametitle}
         \vbox{}
         \ifx\insertframesubtitle\@empty\vskip-2pt%
-        \else\vskip-1ex\fi%
+        \else\vskip-5pt\fi%
         \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
         \strut\insertframetitle\strut\par%
         {%
@@ -105,8 +105,8 @@
         \endgroup%
         \raggedleft%
         \begingroup
-        \ifx\insertframesubtitle\@empty\vskip-2.5ex%
-        \else\vskip-3.5ex\fi%
+        \ifx\insertframesubtitle\@empty\vskip-2.3ex%
+        \else\vskip-3.0ex\fi%
 %    \end{macrocode}
 % Insert the outer logo with 0.7cm height. \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input. The calculation is fixed for a 0.7cm height logo placeholder.
 %    \begin{macrocode}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -155,11 +155,15 @@
   \fi\fi
 %    \end{macrocode}
 %
-%   Color patch for default outer theme.
+%   Color patch for default outer theme. 
+%   And patch the margin to the legacy settings.
 %    \begin{macrocode}
 \if\EqualOption{outer}{nav}{default}
   \setbeamercolor{frametitle}{use=palette primary,
     bg=palette primary.bg,fg=palette primary.fg}
+  \AtBeginDocument{
+    \setbeamertemplate{frametitle}[sjtubeamer][leftskip=0cm,sep=0.3cm]
+  }
 %    \end{macrocode}
 % Since \verb"infolines" outer theme in \verb"beamer" class has redefined the beamer color below which doesn't confirm the standing-free principle, the redefined color will override after the outer theme is loaded. 
 % \verb"structure" beamer color stores the \verb"cprimary". Set the color relative to this for decoupling reasons.

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -118,6 +118,14 @@
       \end{beamercolorbox}%
     }
   }
+%    \end{macrocode}
+%  Make a larger height of frametitle when it is in \verb"default" navigation configuration. This could only be made when it is in \verb"topright" logo position mode.
+%    \begin{macrocode}
+  \if\EqualOption{outer}{nav}{default}
+    \AtBeginDocument{
+      \setbeamertemplate{frametitle}[sjtubeamer][leftskip=0cm,sep=0.3cm]
+    }
+  \fi
 \fi
 %    \end{macrocode}
 %
@@ -155,15 +163,11 @@
   \fi\fi
 %    \end{macrocode}
 %
-%   Color patch for default outer theme. 
-%   And patch the margin to the legacy settings.
+%   Color patch for default outer theme.
 %    \begin{macrocode}
 \if\EqualOption{outer}{nav}{default}
   \setbeamercolor{frametitle}{use=palette primary,
     bg=palette primary.bg,fg=palette primary.fg}
-  \AtBeginDocument{
-    \setbeamertemplate{frametitle}[sjtubeamer][leftskip=0cm,sep=0.3cm]
-  }
 %    \end{macrocode}
 % Since \verb"infolines" outer theme in \verb"beamer" class has redefined the beamer color below which doesn't confirm the standing-free principle, the redefined color will override after the outer theme is loaded. 
 % \verb"structure" beamer color stores the \verb"cprimary". Set the color relative to this for decoupling reasons.

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -113,7 +113,7 @@
         \resizebox{!}{0.7cm}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{5pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
-        \else\vskip0.5ex\fi%
+        \else\vskip0.6ex\fi%
         \if@tempswa\else\vskip-.3cm\fi%
       \end{beamercolorbox}%
     }

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/10 v2.7.2 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/09 v2.7.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/10 v2.7.2 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/09 v2.7.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/10 v2.7.2 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
在 `topright` 模式下减少标题栏的高度以让正文含有更多内容。但是 `default` 维持原本的设计。

|Before|After|
|---|---|
|<img width="550" alt="image" src="https://user-images.githubusercontent.com/61653082/167607022-d846982c-0494-408e-b020-f8b78c59fff7.png">|<img width="550" alt="image" src="https://user-images.githubusercontent.com/61653082/167606786-e742ade0-57d4-4e2f-af36-4378058244fb.png">|