### PR TITLE
fix: maxplus sectioning page shift

### DIFF
--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/09 v2.7.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/10 v2.7.3 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}
@@ -418,8 +418,8 @@
   \usebeamercolor{#1 title}
   \begin{tikzpicture}[overlay]
     \fill [bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
-    rectangle (1*\the\paperwidth, 0.3*\the\paperheight);
-    \node [right, fg] at (-0.2*\the\paperwidth, -0.6*\the\paperheight)
+    rectangle (1*\the\paperwidth, 0.4*\the\paperheight);
+    \node [right, fg] at (-0.2*\the\paperwidth, -0.5*\the\paperheight)
     {\resizebox{1.25\paperwidth}{!}{\sjtugate}};
   \end{tikzpicture}
   \vfil

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -442,6 +442,9 @@
       }
     \fi
   \endgroup
+  \if\EqualOption{cover}{sectype}{section}
+    \vskip8.5ex
+  \fi
   \vfill
 }
 \definesecpage{part}{maxplus}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/09 v2.7.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/10 v2.7.3 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -380,7 +380,7 @@ fontupper=\sffamily,colupper=white}
 
 \begin{commentlist}
   \item \texttt{codeblock} 提供了带行号的代码抄录环境$^*$，第一个可选参数可以用于设置语言与其他抄录选项，第二个必选参数可以设置代码块的标题。
-  \item 需要清理抄录代码在源文件中的缩进，顶格输入。如果想要高亮某一行$^*$，请设置 \verb"escapechar=|" 可选参数后，在该行开头顶格输入 \verb"|\highlightline|"。
+  \item 需要清理抄录代码在源文件中的缩进，顶格输入。如果想要高亮某一行$^*$，设置 \verb"escapechar=|" 可选参数后，在该行开头顶格输入 \verb"|\highlightline|"。
   \item 你也可以直接使用 \texttt{\textbackslash{}codeblockinput}[选项]\{标题\}\{文件\} 用于抄录外部文件$^*$，但请通过 \verb"firstline" 和 \verb"lastline" 选项控制代码行数。
   \item 直接使用 \texttt{listings} 宏包提供的 \texttt{lstlisting} 环境与 \texttt{lstinputlisting} 命令依然可行，\themename\ 已经对其进行了一些预先的优化。
   \item[\faExclamationTriangle] 使用代码块的页其 \texttt{frame} 环境必须添加 \texttt{fragile} 参数。

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/09 v2.7.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/10 v2.7.3 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -666,6 +666,9 @@
       }
     \fi
   \endgroup
+  \if\EqualOption{cover}{sectype}{section}
+    \vskip8.5ex
+  \fi
   \vfill
 }
 %    \end{macrocode}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/09 v2.7.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/10 v2.7.3 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}
@@ -635,8 +635,8 @@
   \usebeamercolor{#1 title}
   \begin{tikzpicture}[overlay]
     \fill [bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
-    rectangle (1*\the\paperwidth, 0.3*\the\paperheight);
-    \node [right, fg] at (-0.2*\the\paperwidth, -0.6*\the\paperheight)
+    rectangle (1*\the\paperwidth, 0.4*\the\paperheight);
+    \node [right, fg] at (-0.2*\the\paperwidth, -0.5*\the\paperheight)
     {\resizebox{1.25\paperwidth}{!}{\sjtugate}};
   \end{tikzpicture}
   \vfil

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -666,6 +666,9 @@
       }
     \fi
   \endgroup
+%    \end{macrocode}
+% Add additional vertical skip for the section page, to align with the subsection page on bottom gate picture.
+%    \begin{macrocode}
   \if\EqualOption{cover}{sectype}{section}
     \vskip8.5ex
   \fi

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/09 v2.7.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/10 v2.7.3 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
修正 `maxplus` 节次页如果该帧没有被设定为 `plain` 会导致的偏移问题。

|Before|After|
|---|---|
|<img width="277" alt="image" src="https://user-images.githubusercontent.com/61653082/167618371-419cb501-9b62-4465-9d04-be16281e214c.png">|<img width="274" alt="image" src="https://user-images.githubusercontent.com/61653082/167630281-ecf29098-5a50-48a4-9ac9-bc7deb401cb0.png">|