### PR TITLE
style: emph, comment and algorithm color

### DIFF
--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}
@@ -82,7 +82,7 @@
 \setbeamercolor{page number in head/foot}{fg=white,bg=}
 \setbeamercolor{frametitle}{use=titlelike,bg=white,fg=titlelike.fg}
 \setbeamercolor{frametitle right}{parent=subsection in head/foot}
-\setbeamercolor{emph}{fg=cprimary!50!csecondary}
+\setbeamercolor{emph}{fg=black}
 \renewcommand<>{\emph}[1]{%
   {\only#2{\usebeamercolor[fg]{emph}\itshape}#1}%
 }

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -82,10 +82,6 @@
 \setbeamercolor{page number in head/foot}{fg=white,bg=}
 \setbeamercolor{frametitle}{use=titlelike,bg=white,fg=titlelike.fg}
 \setbeamercolor{frametitle right}{parent=subsection in head/foot}
-\setbeamercolor{emph}{fg=black}
-\renewcommand<>{\emph}[1]{%
-  {\only#2{\usebeamercolor[fg]{emph}\itshape}#1}%
-}
 \setbeamercolor{alerted text}{fg=cprimary}
 \endinput
 %%

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}
@@ -293,6 +293,14 @@
     \newcolumntype{L}[1]{>{\begin{pgfplotstablecoltype}[#1]}
             r<{\end{pgfplotstablecoltype}}}
   }{}
+  \if\EqualOption{inner}{lang}{zh}
+    \def\sjtubeamer@algorithmName{算法}
+  \else
+    \def\sjtubeamer@algorithmName{Algorithm}
+  \fi
+  \@ifpackageloaded{algorithm2e}{%
+    \SetAlgorithmName{\sjtubeamer@algorithmName}{\sjtubeamer@algorithmName}{}
+  }
   \def\Hy@WarnOptionDisabled#1{
     \def\next{#1}%
     \ifx\next pdfauthor %

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -295,9 +295,7 @@
   }{}
   \if\EqualOption{inner}{lang}{zh}
     \@ifpackageloaded{algorithm2e}{%
-      \SetAlgorithmName{算法}{算法}{算法索引}
-      % \SetAlgoProcName{过程}{过程}
-      % \SetAlgoFuncName{函数}{函数}
+      \SetAlgorithmName{\algorithmname}{\algorithmname}{\algorithmname{}索引}
     }
   \fi
   \def\Hy@WarnOptionDisabled#1{

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -296,6 +296,8 @@
   \if\EqualOption{inner}{lang}{zh}
     \@ifpackageloaded{algorithm2e}{%
       \SetAlgorithmName{算法}{算法}{算法索引}
+      % \SetAlgoProcName{过程}{过程}
+      % \SetAlgoFuncName{函数}{函数}
     }
   \fi
   \def\Hy@WarnOptionDisabled#1{

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -294,13 +294,10 @@
             r<{\end{pgfplotstablecoltype}}}
   }{}
   \if\EqualOption{inner}{lang}{zh}
-    \def\sjtubeamer@algorithmName{算法}
-  \else
-    \def\sjtubeamer@algorithmName{Algorithm}
+    \@ifpackageloaded{algorithm2e}{%
+      \SetAlgorithmName{算法}{算法}{算法索引}
+    }
   \fi
-  \@ifpackageloaded{algorithm2e}{%
-    \SetAlgorithmName{\sjtubeamer@algorithmName}{\sjtubeamer@algorithmName}{}
-  }
   \def\Hy@WarnOptionDisabled#1{
     \def\next{#1}%
     \ifx\next pdfauthor %

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -169,7 +169,7 @@
   basicstyle=\ttfamily\small,
   keywordstyle=\color{cprimary},%
   stringstyle=\color{csecondary},%
-  commentstyle=\color{ctertiary!80!gray},%
+  commentstyle=\color{ctertiary!50!gray},%
   columns=flexible,
   extendedchars=false,
   showstringspaces=false,

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/main.tex
+++ b/main.tex
@@ -159,7 +159,8 @@
   \vspace*{2ex}
 
   \begin{itemize}
-    \item 本示例文档的源码结构适用于简短的单次报告，仅展示 \beamer{} 文档类的通用功能。为发挥 \SJTUBeamer{} 的全部功能，参见发布区 \link{https://github.com/sjtug/SJTUBeamer/releases} 的用户手册与开发文档。
+    \item 本示例文档的源码结构适用于简短的单次报告，仅展示 \beamer{} 文档类的通用功能，更多地在使用 \SJTUBeamer{} 的样式信息。
+    \item 为发挥 \SJTUBeamer{} 的全部功能，参见发布区 \link{https://github.com/sjtug/SJTUBeamer/releases} 的用户手册与开发文档。
     \item 就制作一组讲座而言，相关源码结构可以参考新讲座 \link{https://github.com/sjtug/sjtulib-latex-talk/tree/logcreative-2022}。新讲座使用了社区版主题的同时也展示了 \SJTUBeamer{} 的特殊用法。
   \end{itemize}
 

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/11 v2.8.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/15 v2.8.1 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/11 v2.8.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/11 v2.8.1 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/11 v2.8.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/15 v2.8.1 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/11 v2.8.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/11 v2.8.1 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -379,7 +379,7 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[1]{step10.tex}
 
 \begin{commentlist}
-  \item \cmd{alert} 会改变文字颜色为主题色。\cmd{emph} 会改变文字颜色的同时，还会将英文字体变为斜体$^*$。
+  \item \cmd{alert} 会改变文字颜色为主题色。\cmd{emph} 会将英文字体变为斜体。
   \item \cmd{paragraph} 和 \cmd{highlight} 都会在文字底部添加纯色方块$^*$，区别在于后者可以设置背景颜色。
   \item \cmd{stamptext} 可以用于生成以印记形为底的高亮小块$^*$，需要将高亮的文字数目控制在一个中文字或两个英文字。
 \end{commentlist}
@@ -592,9 +592,9 @@ fontupper=\sffamily,colupper=white}
   \centering
   \begin{tabular}{>{\ttfamily}c>{\ttfamily}c>{\ttfamily}c}
     \hline
-    \textbackslash{}makebottom & \textbackslash{}emph          & \textbackslash{}highlight  \\
-    \textbackslash{}paragraph  & codeblock                     & \textbackslash{}stamparray \\
-    \textbackslash{}*logo      & \textbackslash{}sjtubadge     & stampbox                   \\
+    \textbackslash{}makebottom & bibliolist                    & \textbackslash{}highlight    \\
+    \textbackslash{}paragraph  & codeblock                     & \textbackslash{}stamparray   \\
+    \textbackslash{}*logo      & \textbackslash{}sjtubadge     & stampbox                     \\
     \textbackslash{}stamptext  & \textbackslash{}highlightline & \textbackslash{}usesjtutheme \\
     \hline
   \end{tabular}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -427,7 +427,7 @@ fontupper=\sffamily,colupper=white}
 \examplecode{stepalgorithm.tex}
 
 \begin{commentlist}
-  \item \themename{} 对 \env{algorithm} 环境的标题在中文环境下进行了汉化$^*$，但是对于 \env{procedure} 和 \env{function} 则没有。请注意使用 \opt{H} 参数强制浮动体位置。
+  \item \themename{} 对 \env{algorithm} 环境的标题在中文环境下进行了汉化$^*$，但是对于 \env{procedure} 和 \env{function} 则没有。请注意使用 \texttt{H} 参数强制浮动体位置。
   \item 如果算法过长，考虑使用 \cmd{scalebox} 对算法环境进行缩小。
   \item 如果还需要在右侧添加说明，这时请使用 \env{minipage} 环境创建纵向盒子。
 \end{commentlist}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -421,7 +421,7 @@ fontupper=\sffamily,colupper=white}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.5\textwidth]{tutorial/stepalgo.pdf}
+  \includegraphics[width=0.4\textwidth]{tutorial/stepalgo.pdf}
 \end{figure}
 
 \examplecode{stepalgorithm.tex}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -359,6 +359,8 @@ fontupper=\sffamily,colupper=white}
 \end{verbatim}
 以展示备注幻灯片（幻灯片内使用 \cmd{note} 标记备注内容）于每页右侧。使用该软件以自动地识别备注区域展示在演示者屏幕上。
 
+\examplecode{stepdual.tex}
+
 \begin{figure}[h]
   \centering
   \includegraphics[width=0.7\textwidth]{tutorial/stepdual.pdf}\\
@@ -399,16 +401,35 @@ fontupper=\sffamily,colupper=white}
 
 \chapter{代码}
 
+\section{代码抄录}
+
 \themename\ 提供了代码抄录的区块环境。
 
 \beamerdemo[1]{step13.tex}
 
 \begin{commentlist}
   \item \texttt{codeblock} 提供了带行号的代码抄录环境$^*$，第一个可选参数可以用于设置语言与其他抄录选项，第二个必选参数可以设置代码块的标题。
-  \item 需要清理抄录代码在源文件中的缩进，顶格输入。如果想高亮某一行$^*$，设置 \verb"escapechar=|" 可选参数后，在该行开头顶格输入 \verb"|\highlightline|"。
+  \item 需要清理抄录代码在源文件中的缩进，顶格输入。如果想高亮某一行$^*$，设置 \verb"escapechar=|" 可选参数后，该行开头顶格输入 \verb"|\highlightline|"。
   \item 你也可以直接使用 \cmd{codeblockinput}[选项]\{标题\}\{文件\} 用于抄录外部文件$^*$，但请通过 \verb"firstline" 和 \verb"lastline" 选项控制代码行数。
   \item 直接使用 \texttt{listings} 宏包提供的 \texttt{lstlisting} 环境与 \texttt{lstinputlisting} 命令依然可行，\themename\ 已经对其进行了一些预先的优化。
   \item[\faExclamationTriangle] 使用代码块的页其 \texttt{frame} 环境必须添加 \texttt{fragile} 参数。
+\end{commentlist}
+
+\section{伪代码}
+
+使用 \pkg{algorithm2e} 宏包编写伪代码。
+
+\begin{figure}[h]
+  \centering
+  \includegraphics[width=\textwidth]{tutorial/stepalgo.pdf}
+\end{figure}
+
+\examplecode{stepalgorithm.tex}
+
+\begin{commentlist}
+  \item \themename{} 对 \env{algorithm} 环境的标题在中文环境下进行了汉化$^*$，但是对于 \env{procedure} 和 \env{function} 则没有。
+  \item 如果算法过长，考虑使用 \cmd{scalebox} 对算法环境进行缩小。
+  \item 如果还需要在右侧添加说明，这时请使用 \env{minipage} 环境创建纵向盒子。
 \end{commentlist}
 
 

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -427,7 +427,7 @@ fontupper=\sffamily,colupper=white}
 \examplecode{stepalgorithm.tex}
 
 \begin{commentlist}
-  \item \themename{} 对 \env{algorithm} 环境的标题在中文环境下进行了汉化$^*$，但是对于 \env{procedure} 和 \env{function} 则没有。
+  \item \themename{} 对 \env{algorithm} 环境的标题在中文环境下进行了汉化$^*$，但是对于 \env{procedure} 和 \env{function} 则没有。请注意使用 \opt{H} 参数强制浮动体位置。
   \item 如果算法过长，考虑使用 \cmd{scalebox} 对算法环境进行缩小。
   \item 如果还需要在右侧添加说明，这时请使用 \env{minipage} 环境创建纵向盒子。
 \end{commentlist}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -409,7 +409,7 @@ fontupper=\sffamily,colupper=white}
 
 \begin{commentlist}
   \item \texttt{codeblock} 提供了带行号的代码抄录环境$^*$，第一个可选参数可以用于设置语言与其他抄录选项，第二个必选参数可以设置代码块的标题。
-  \item 需要清理抄录代码在源文件中的缩进，顶格输入。如果想高亮某一行$^*$，设置 \verb"escapechar=|" 可选参数后，该行开头顶格输入 \verb"|\highlightline|"。
+  \item 需要清理抄录代码在源文件中的缩进，顶格输入。若想高亮某一行$^*$，设置 \verb"escapechar=|" 可选参数后，该行开头顶格输入 \verb"|\highlightline|"。
   \item 你也可以直接使用 \cmd{codeblockinput}[选项]\{标题\}\{文件\} 用于抄录外部文件$^*$，但请通过 \verb"firstline" 和 \verb"lastline" 选项控制代码行数。
   \item 直接使用 \texttt{listings} 宏包提供的 \texttt{lstlisting} 环境与 \texttt{lstinputlisting} 命令依然可行，\themename\ 已经对其进行了一些预先的优化。
   \item[\faExclamationTriangle] 使用代码块的页其 \texttt{frame} 环境必须添加 \texttt{fragile} 参数。
@@ -421,7 +421,7 @@ fontupper=\sffamily,colupper=white}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=\textwidth]{tutorial/stepalgo.pdf}
+  \includegraphics[width=0.5\textwidth]{tutorial/stepalgo.pdf}
 \end{figure}
 
 \examplecode{stepalgorithm.tex}

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -151,18 +151,19 @@ This command will also move the generated style files to the root directory.
 %     unpack $\rightarrow$ \verb"min.tex" $\rightarrow$ documentations
 % \end{center}
 Since the doc has a lot of dependencies (or unit tests), you can cache the demo files to \verb"support/tutorial" directory.
-\begin{verbatim}
-        cd support/tutorial
-        ./cache_pdf.sh
-    \end{verbatim}
-or you could remove all the cached files by
-\begin{verbatim}
-        ./clean_pdf.sh
-    \end{verbatim}
-and don't forget to back to the source code directory if you want to use \verb"l3build":
-\begin{verbatim}
-        cd ../..
-    \end{verbatim}
+% \begin{verbatim}
+%         cd support/tutorial
+%         ./cache_pdf.sh
+%     \end{verbatim}
+% or you could remove all the cached files by
+% \begin{verbatim}
+%         ./clean_pdf.sh
+%     \end{verbatim}
+% and don't forget to back to the source code directory if you want to use \verb"l3build":
+% \begin{verbatim}
+%         cd ../..
+%     \end{verbatim}
+Change the variable in \verb"build.lua": \verb"cachedemo=true" to cache the demo automatically, and remove the variable to clean the cached files.
 We highly recommend that using *nix to compile the doc.
 
 \fcmd{l3build save color} If you make some modification to the framework (except \verb"sjtucover") and change the result. To save the current result as a reference, run this command and \verb"color" could be exchanged by any of the test units above.

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -151,18 +151,6 @@ This command will also move the generated style files to the root directory.
 %     unpack $\rightarrow$ \verb"min.tex" $\rightarrow$ documentations
 % \end{center}
 Since the doc has a lot of dependencies (or unit tests), you can cache the demo files to \verb"support/tutorial" directory.
-% \begin{verbatim}
-%         cd support/tutorial
-%         ./cache_pdf.sh
-%     \end{verbatim}
-% or you could remove all the cached files by
-% \begin{verbatim}
-%         ./clean_pdf.sh
-%     \end{verbatim}
-% and don't forget to back to the source code directory if you want to use \verb"l3build":
-% \begin{verbatim}
-%         cd ../..
-%     \end{verbatim}
 Change the variable in \verb"build.lua": \verb"cachedemo=true" to cache the demo automatically, and remove the variable to clean the cached files.
 We highly recommend that using *nix to compile the doc.
 

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -153,11 +153,11 @@
 %
 %   Set the emphasized color and redefine the emphasizing command to make the text both italic for ASCII character and colored in the middle color of cprimary and csecondary.
 %
-%   The redefinition is required since beamer class has redefined the \verb"\emph" command to make it not nested. According to LearnLaTeX.org, the emphasized color is defined to make contrast in presentation.
+%   The redefinition is required since beamer class has redefined the \verb"\emph" command to make it not nested.
 %
 %   For ASCII character, the italic part dominates, as it is quite different from the normal roman font. As for chinese character, the color part dominates, since it is often in bolder shape and changing to other font will make the layout messy.
 %    \begin{macrocode}
-\setbeamercolor{emph}{fg=cprimary!50!csecondary}
+\setbeamercolor{emph}{fg=black}
 \renewcommand<>{\emph}[1]{%
   {\only#2{\usebeamercolor[fg]{emph}\itshape}#1}%
 }

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -151,18 +151,6 @@
 \setbeamercolor{frametitle right}{parent=subsection in head/foot}
 %    \end{macrocode}
 %
-%   Set the emphasized color and redefine the emphasizing command to make the text both italic for ASCII character and colored in the middle color of cprimary and csecondary.
-%
-%   The redefinition is required since beamer class has redefined the \verb"\emph" command to make it not nested.
-%
-%   For ASCII character, the italic part dominates, as it is quite different from the normal roman font. As for chinese character, the color part dominates, since it is often in bolder shape and changing to other font will make the layout messy.
-%    \begin{macrocode}
-\setbeamercolor{emph}{fg=black}
-\renewcommand<>{\emph}[1]{%
-  {\only#2{\usebeamercolor[fg]{emph}\itshape}#1}%
-}
-%    \end{macrocode}
-%
 %   As is native to beamer, you could also use \verb"\alert" command to highlight the text. The color is redirected to the cprimary.
 %    \begin{macrocode}
 \setbeamercolor{alerted text}{fg=cprimary}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -585,13 +585,13 @@
             r<{\end{pgfplotstablecoltype}}}
   }{}
 %    \end{macrocode}
-%  Translate the name of ``Algorithm'' in algorithm2e if it is in \verb"zh" language. The name of procedure and function are not translated for the reason that it looks unprofessional to translate the dedicated use of the words. You could uncomment the lines if you want it translated.
+%  Translate the name of ``Algorithm'' in algorithm2e if it is in \verb"zh" language. The name of procedure and function are not translated for the reason that it looks unprofessional to translate the dedicated use of the words. 
+%  \verb"\algorithmname" is translated by \verb"ctex" package or \verb"ctexbeamer" class. If you use \verb"CJK", it will not get translated.
+%  The third paramter indicates the caption of the list of algorithms, but it is not often to be used in \verb"beamer" class.
 %    \begin{macrocode}
   \if\EqualOption{inner}{lang}{zh}
     \@ifpackageloaded{algorithm2e}{%
-      \SetAlgorithmName{算法}{算法}{算法索引}
-      % \SetAlgoProcName{过程}{过程}
-      % \SetAlgoFuncName{函数}{函数}
+      \SetAlgorithmName{\algorithmname}{\algorithmname}{\algorithmname{}索引}
     }
   \fi
 %    \end{macrocode}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -585,11 +585,13 @@
             r<{\end{pgfplotstablecoltype}}}
   }{}
 %    \end{macrocode}
-%  Translate the name of ``Algorithm'' in algorithm2e if it is in \verb"zh" language.
+%  Translate the name of ``Algorithm'' in algorithm2e if it is in \verb"zh" language. The name of procedure and function are not translated for the reason that it looks unprofessional to translate the dedicated use of the words. You could uncomment the lines if you want it translated.
 %    \begin{macrocode}
   \if\EqualOption{inner}{lang}{zh}
     \@ifpackageloaded{algorithm2e}{%
       \SetAlgorithmName{算法}{算法}{算法索引}
+      % \SetAlgoProcName{过程}{过程}
+      % \SetAlgoFuncName{函数}{函数}
     }
   \fi
 %    \end{macrocode}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -585,6 +585,17 @@
             r<{\end{pgfplotstablecoltype}}}
   }{}
 %    \end{macrocode}
+%  Translate the name of ``Algorithm'' in algorithm2e if it is in \verb"zh" language.
+%    \begin{macrocode}
+  \if\EqualOption{inner}{lang}{zh}
+    \def\sjtubeamer@algorithmName{算法}
+  \else
+    \def\sjtubeamer@algorithmName{Algorithm}
+  \fi
+  \@ifpackageloaded{algorithm2e}{%
+    \SetAlgorithmName{\sjtubeamer@algorithmName}{\sjtubeamer@algorithmName}{}
+  }
+%    \end{macrocode}
 % Disable the warning from \verb"hyperref" which conflicts the setting in C\TeX{} or CJK. It has to be manually disabled.
 %    \begin{macrocode}
   \def\Hy@WarnOptionDisabled#1{

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -588,13 +588,10 @@
 %  Translate the name of ``Algorithm'' in algorithm2e if it is in \verb"zh" language.
 %    \begin{macrocode}
   \if\EqualOption{inner}{lang}{zh}
-    \def\sjtubeamer@algorithmName{算法}
-  \else
-    \def\sjtubeamer@algorithmName{Algorithm}
+    \@ifpackageloaded{algorithm2e}{%
+      \SetAlgorithmName{算法}{算法}{算法索引}
+    }
   \fi
-  \@ifpackageloaded{algorithm2e}{%
-    \SetAlgorithmName{\sjtubeamer@algorithmName}{\sjtubeamer@algorithmName}{}
-  }
 %    \end{macrocode}
 % Disable the warning from \verb"hyperref" which conflicts the setting in C\TeX{} or CJK. It has to be manually disabled.
 %    \begin{macrocode}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -417,7 +417,7 @@
   basicstyle=\ttfamily\small,
   keywordstyle=\color{cprimary},%
   stringstyle=\color{csecondary},%
-  commentstyle=\color{ctertiary!80!gray},%
+  commentstyle=\color{ctertiary!50!gray},%
   columns=flexible,
   extendedchars=false,
   showstringspaces=false,

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/11 v2.8.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/11 v2.8.1 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/11 v2.8.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/11 v2.8.1 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/11 v2.8.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/15 v2.8.1 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/11 v2.8.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/15 v2.8.1 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/11 v2.8.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/11 v2.8.1 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/support/tutorial/stepalgo.tex
+++ b/src/support/tutorial/stepalgo.tex
@@ -1,0 +1,45 @@
+\documentclass{ctexbeamer}
+\usetheme[min]{sjtubeamer}
+\usepackage[ruled, linesnumbered]{algorithm2e}
+\begin{document}
+\begin{frame}
+  \scalebox{0.5}{
+    \begin{algorithm}[H]
+      \caption{A* 多序列比对}\label{alg:astar}
+      \KwIn{$L$个字符串列表$S$,$\alpha$,$\delta$}
+      \KwOut{minimum cost}
+      \BlankLine
+      $dist[\cdot]\leftarrow\infty$\;
+      $move[\cdot]\leftarrow 0$\;
+      $dist[start]\leftarrow 0$\;
+      $move[start]\leftarrow 0$\;
+      $openSet\leftarrow\textsc{Min-Heap}()$\;
+      $openSet[start]=h(start)$\;
+      $closeSet\leftarrow \{\}$\;
+      \Repeat{$openSet$ is empty}{
+        $current\leftarrow openSet$.pop()\;
+        \If{$current$=$finish$}{
+          \Return{$dist[current]$}\;
+        }
+
+        $closeSet$.add($current$)\;
+        \ForEach{available move of $current$}{
+          $n\leftarrow$\texttt{pos}$+$\emph{available move}\;
+          $g=dist(\mathit{current})+cost(\text{\emph{available move}})$\;
+          \If{$g<dist[n]$}{
+            $move[n]\leftarrow$\emph{available move}\;
+            $dist[n]\leftarrow g$\;
+            \If{$n$ not in $closeSet$}{
+              $openSet[n]\leftarrow g+h(n)$\;
+            }
+          }
+        }
+      }
+      \Return{$\infty$}\;
+    \end{algorithm}
+  }
+  \begin{minipage}[c]{0.45\textwidth}
+    对该算法的说明。
+  \end{minipage}
+\end{frame}
+\end{document}

--- a/src/support/tutorial/stepalgorithm.tex
+++ b/src/support/tutorial/stepalgorithm.tex
@@ -1,0 +1,21 @@
+\documentclass{ctexbeamer}
+\usetheme[min]{sjtubeamer}
+\usepackage[ruled, linesnumbered]{algorithm2e}
+\begin{document}
+\begin{frame}
+  \scalebox{0.5}{
+    \begin{algorithm}[H]
+      \caption{A* 多序列比对}\label{alg:astar}
+      \KwIn{$L$个字符串列表$S$,$\alpha$,$\delta$}
+      \KwOut{minimum cost}
+      \BlankLine
+      $dist[\cdot]\leftarrow\infty$\;
+      % 算法内容...
+      \Return{$\infty$}\;
+    \end{algorithm}
+  }
+  \begin{minipage}[c]{0.45\textwidth}
+    对该算法的说明。
+  \end{minipage}
+\end{frame}
+\end{document}


### PR DESCRIPTION
可能将 `\emph` 颜色使用红色有点奇怪，改用了 beamer 默认定义。

|Before|After|
|---|---|
|<img width="432" alt="image" src="https://user-images.githubusercontent.com/61653082/168467942-9953d0d2-f60a-4c33-b33a-de128cdd4fa7.png">|<img width="432" alt="image" src="https://user-images.githubusercontent.com/61653082/168467929-23e03a93-79a8-47dc-92b4-b30fb2d48242.png">|