### PR TITLE
fix: min title page combo logo space

### DIFF
--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/15 v2.8.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/16 v2.8.2 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -160,7 +160,7 @@
       \else
       \ifx\insertlogo\@empty%
         \else
-        {\hskip0pt \vrule width0.5pt}\hskip3pt
+        {\hskip0pt\vrule width0.5pt}\hskip0pt
       \fi
       \if\EqualOption{inner}{lang}{en}
       \vbox to 1cm{
@@ -175,13 +175,13 @@
           \vfill
         }
       \else
-      \vbox{
+      \hskip3pt\vbox{
         \fontsize{13pt}{0pt}\selectfont
         \insertinstitute
-        \par\noindent\vskip0.15em
+        \par\noindent\vskip0.14em
         \fontsize{5pt}{0pt}\selectfont
         \textsc{\insertshortinstitute}
-        \baselineskip 3.2pt
+        \baselineskip 3.9pt
         \par~
       }
       \fi

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/15 v2.8.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/16 v2.8.2 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/15 v2.8.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -255,7 +255,7 @@
       \else
       \ifx\insertlogo\@empty%
         \else
-        {\hskip0pt \vrule width0.5pt}\hskip3pt
+        {\hskip0pt\vrule width0.5pt}\hskip0pt
       \fi
       \if\EqualOption{inner}{lang}{en}
       \vbox to 1cm{
@@ -270,13 +270,13 @@
           \vfill
         }
       \else
-      \vbox{
+      \hskip3pt\vbox{
         \fontsize{13pt}{0pt}\selectfont
         \insertinstitute
-        \par\noindent\vskip0.15em
+        \par\noindent\vskip0.14em
         \fontsize{5pt}{0pt}\selectfont
         \textsc{\insertshortinstitute}
-        \baselineskip 3.2pt
+        \baselineskip 3.9pt
         \par~
       }
       \fi

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/15 v2.8.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/16 v2.8.2 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/15 v2.8.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/16 v2.8.2 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
调整 `min` 主题的标题页徽标间隙。