### PR TITLE
feat: stamp TOC style

### DIFF
--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}
@@ -117,7 +117,8 @@
 \AtBeginPart{
   \makepart
 }
-\useinnertheme{circles}
+\setbeamertemplate{items}[circle]
+\setbeamertemplate{sections/subsections in toc}[stamp]
 \setlength\leftmargini{1.4em}
 \setlength\leftmarginii{1.4em}
 \setlength\leftmarginiii{1.4em}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/main.tex
+++ b/main.tex
@@ -131,7 +131,7 @@
 % 使用节目录
 \AtBeginSection[]{
   \begin{frame}
-    \tableofcontents[currentsection] % 传统节目录             
+    \tableofcontents[currentsection,subsectionstyle=show/show/hide] % 传统节目录             
     % \sectionpage                   % 节页
   \end{frame}
 }
@@ -139,7 +139,7 @@
 % 使用小节目录
 \AtBeginSubsection[]{                  % 在每小节开始
   \begin{frame}
-    \tableofcontents[currentsection,currentsubsection] % 传统小节目录             
+    \tableofcontents[currentsection,subsectionstyle=show/shaded/hide] % 传统小节目录             
     % \subsectionpage                                  % 小节页
   \end{frame}
 }
@@ -166,7 +166,7 @@
 \end{frame}
 
 \begin{frame}{目录}
-  \tableofcontents
+  \tableofcontents[hideallsubsections]
 \end{frame}
 
 \include{contents/introduction}

--- a/main.tex
+++ b/main.tex
@@ -131,16 +131,20 @@
 % 使用节目录
 \AtBeginSection[]{
   \begin{frame}
-    \tableofcontents[currentsection,subsectionstyle=show/show/hide] % 传统节目录             
-    % \sectionpage                   % 节页
+    %% 使用传统节目录
+    \tableofcontents[currentsection,subsectionstyle=show/show/hide]
+    %% 或者使用节页
+    % \sectionpage
   \end{frame}
 }
 
 % 使用小节目录
 \AtBeginSubsection[]{                  % 在每小节开始
   \begin{frame}
-    \tableofcontents[currentsection,subsectionstyle=show/shaded/hide] % 传统小节目录             
-    % \subsectionpage                                  % 小节页
+    %% 使用传统小节目录
+    \tableofcontents[currentsection,subsectionstyle=show/shaded/hide]
+    %% 或者使用小节页
+    % \subsectionpage
   \end{frame}
 }
 

--- a/main.tex
+++ b/main.tex
@@ -131,7 +131,7 @@
 % 使用节目录
 \AtBeginSection[]{
   \begin{frame}
-    %% 使用传统节目录
+    %% 使用传统节目录，也可以将 subsectionstyle=... 换成 hideallsubsections 以隐藏所有小节信息
     \tableofcontents[currentsection,subsectionstyle=show/show/hide]
     %% 或者使用节页
     % \sectionpage
@@ -170,7 +170,7 @@
 \end{frame}
 
 \begin{frame}{目录}
-  \tableofcontents[hideallsubsections]
+  \tableofcontents[hideallsubsections]  % 隐藏所有小节信息
 \end{frame}
 
 \include{contents/introduction}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/16 v2.8.2 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/17 v2.8.3 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}
@@ -575,6 +575,13 @@
   % and in the main.tex:
   %    \usetheme[my]{sjtubeamer}\usepackage{mycover}
   %
+}
+\defbeamertemplate{section in toc}{stamp}{
+  \leavevmode\leftskip=8mm\stamptext[structure]{\inserttocsectionnumber}
+  \hspace{0.3em}\inserttocsection\par\vspace{3pt}
+}
+\defbeamertemplate{subsection in toc}{stamp}{
+  \vspace{3pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
 }
 \endinput
 %%

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -577,11 +577,11 @@
   %
 }
 \defbeamertemplate{section in toc}{stamp}{
-  \leavevmode\leftskip=8mm\stamptext[structure]{\inserttocsectionnumber}
-  \hspace{0.3em}\inserttocsection\par\vspace{3pt}
+  \vspace{2.5pt}\leavevmode\leftskip=8mm\stamptext[structure]{\inserttocsectionnumber}
+  \hspace{0.3em}\inserttocsection\par\vspace{0.5pt}
 }
 \defbeamertemplate{subsection in toc}{stamp}{
-  \vspace{3pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
+  \vspace{1.5pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
 }
 \defbeamertemplate{subsubsection in toc}{stamp}{
   \leavevmode\hspace{40mm}\normalsize\usebeamerfont{subsection in

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -583,6 +583,11 @@
 \defbeamertemplate{subsection in toc}{stamp}{
   \vspace{3pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
 }
+\defbeamertemplate{subsubsection in toc}{stamp}{
+  \leavevmode\hspace{40mm}\normalsize\usebeamerfont{subsection in
+  toc}\usebeamerfont{subsubsection in toc}%
+  \inserttocsubsubsection\par
+}
 \endinput
 %%
 %% End of file `sjtucover.sty'.

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/16 v2.8.2 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/17 v2.8.3 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -283,7 +283,7 @@ fontupper=\sffamily,colupper=white}
 
 \section{单页目录}
 
-传统的插入目录的方法就是使用标准的目录命令。
+传统的插入目录的方法就是使用标准的目录命令，使用 \opt{hideallsubsections} 隐藏所有小节标题。
 
 \beamerdemo[1]{step6+.tex}
 
@@ -319,7 +319,10 @@ fontupper=\sffamily,colupper=white}
 
 \begin{commentlist}
   \item 如果想要在幻灯片列表环境产生类似的“渐进切换”效果，可以在 \texttt{itemize} 环境的每一条后使用 \cmd{pause} 命令。或者是 \cmd{begin\{itemize\}[<+->]}。
-  \item \cmd{tableofcontents[currentsection, currentsubsection]} 用于小节页。
+  \item \opt{subsectionstyle} 用于指定小节标题的显示策略，三个参数分别代表当前小节、本节中其他小节和其他节的小节该如何显示。\opt{show} 将显示，\opt{shaded} 将半显示，\opt{hide} 将隐藏。推荐对于 \themename\ 采用这种设置方法。
+  \item 如果想使用普通的圆形目录结构，在导言区添加\begin{verbatim}
+    \setbeamertemplate{sections/subsections in toc}[circle]
+  \end{verbatim}
 \end{commentlist}
 
 \chapter{播放}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -298,8 +298,7 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[4]{step7+.tex}
 
 \begin{commentlist}
-  \item \cmd{AtBeginSubsection} 用于指定每小节开始时的动作，也可以将 \opt{subsectionstyle} 换成 \opt{hideallsubsections} 以隐藏所有小节标题。
-  \item 后文的 \cmd{AtBeginSection} 用于指定每节开始时的动作。
+  \item \cmd{AtBeginSubsection} 用于指定每小节开始时的动作，后文的 \cmd{AtBeginSection} 用于指定每节开始时的动作。
 \end{commentlist}
 
 \section{分割部分}
@@ -320,7 +319,18 @@ fontupper=\sffamily,colupper=white}
 
 \begin{commentlist}
   \item 如果想要在幻灯片列表环境产生类似的“渐进切换”效果，可以在 \texttt{itemize} 环境的每一条后使用 \cmd{pause} 命令。或者是 \cmd{begin\{itemize\}[<+->]}。
-  \item \opt{subsectionstyle} 用于指定小节标题的显示策略，三个参数分别代表当前小节、本节中其他小节和其他节的小节该如何显示。\opt{show} 将显示，\opt{shaded} 将半显示，\opt{hide} 将隐藏。推荐对于 \themename\ 采用这种设置方法。
+  \item \opt{subsectionstyle} 用于指定小节标题的显示策略，三个参数分别代表当前小节、本节中其他小节和其他节的小节该如何显示。\opt{show} 将显示，\opt{shaded} 将半显示，\opt{hide} 将隐藏。在 \themename\ 中推荐设置节目录为
+  \begin{verbatim}
+    \tableofcontents[currentsection, subsectionstyle=show/show/hide]
+  \end{verbatim}
+  也可以设置 \opt{hideallsubsections} 以隐藏所有小节标题与目录页保持一致
+  \begin{verbatim}
+    \tableofcontents[currentsection, hideallsubsections]
+  \end{verbatim}
+  设置小节目录为
+  \begin{verbatim}
+    \tableofcontents[currentsection, subsectionstyle=show/shaded/hide]
+  \end{verbatim}
   \item 如果想使用普通的圆形目录结构，在导言区添加\begin{verbatim}
     \setbeamertemplate{sections/subsections in toc}[circle]
   \end{verbatim}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -298,7 +298,8 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[4]{step7+.tex}
 
 \begin{commentlist}
-  \item \cmd{AtBeginSubsection} 用于指定每小节开始时的动作，后文的 \cmd{AtBeginSection} 用于指定每节开始时的动作。
+  \item \cmd{AtBeginSubsection} 用于指定每小节开始时的动作。
+  \item 后文的 \cmd{AtBeginSection} 用于指定每节开始时的动作。
 \end{commentlist}
 
 \section{分割部分}
@@ -320,20 +321,13 @@ fontupper=\sffamily,colupper=white}
 \begin{commentlist}
   \item 如果想要在幻灯片列表环境产生类似的“渐进切换”效果，可以在 \texttt{itemize} 环境的每一条后使用 \cmd{pause} 命令。或者是 \cmd{begin\{itemize\}[<+->]}。
   \item \opt{subsectionstyle} 用于指定小节标题的显示策略，三个参数分别代表当前小节、本节中其他小节和其他节的小节该如何显示。\opt{show} 将显示，\opt{shaded} 将半显示，\opt{hide} 将隐藏。在 \themename\ 中推荐设置节目录为
-  \begin{verbatim}
-    \tableofcontents[currentsection, subsectionstyle=show/show/hide]
-  \end{verbatim}
+  \begin{verbatim}\tableofcontents[currentsection, subsectionstyle=show/show/hide]\end{verbatim}
   也可以设置 \opt{hideallsubsections} 以隐藏所有小节标题与目录页保持一致
-  \begin{verbatim}
-    \tableofcontents[currentsection, hideallsubsections]
-  \end{verbatim}
+  \begin{verbatim}\tableofcontents[currentsection, hideallsubsections]\end{verbatim}
   设置小节目录为
-  \begin{verbatim}
-    \tableofcontents[currentsection, subsectionstyle=show/shaded/hide]
-  \end{verbatim}
-  \item 如果想使用普通的圆形目录结构，在导言区添加\begin{verbatim}
-    \setbeamertemplate{sections/subsections in toc}[circle]
-  \end{verbatim}
+  \begin{verbatim}\tableofcontents[currentsection, subsectionstyle=show/shaded/hide]\end{verbatim}
+  \item 如果想使用普通的圆形目录结构，在导言区添加
+  \begin{verbatim}\setbeamertemplate{sections/subsections in toc}[circle]\end{verbatim}
 \end{commentlist}
 
 \chapter{播放}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -298,7 +298,7 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[4]{step7+.tex}
 
 \begin{commentlist}
-  \item \cmd{AtBeginSubsection} 用于指定每小节开始时的动作。
+  \item \cmd{AtBeginSubsection} 用于指定每小节开始时的动作，也可以将 \opt{subsectionstyle} 换成 \opt{hideallsubsections} 以隐藏所有小节标题。
   \item 后文的 \cmd{AtBeginSection} 用于指定每节开始时的动作。
 \end{commentlist}
 

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -72,6 +72,7 @@ fontupper=\sffamily,colupper=white}
 \newcommand{\cls}[1]{\texttt{#1}}
 \newcommand{\env}[1]{\texttt{#1}}
 \newcommand{\pkg}[1]{\texttt{#1}}
+\newcommand{\opt}[1]{\texttt{#1}}
 
 \tcbuselibrary{skins,raster}
 \newtcbinputlisting[auto counter]{\beamerdemo}[2][1]{

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -283,10 +283,25 @@
 %
 % \subsubsection{Itemize Environments}
 %
-%   Set the item marker to circle and set the marker for section and subsection in TOC (Table of Contents) to circle.
+%   Set the item and enumerate style to circled one.
 %    \begin{macrocode}
-\useinnertheme{circles}
+\setbeamertemplate{items}[circle]
 %    \end{macrocode}
+%
+%   Set the marker for section and subsection in TOC (Table of Contents) to \verb"stamp" style provided in \verb"sjtucover".
+%   NOTICE: the recommended setup to use the following in full TOC
+%   \begin{verbatim}\tableofcontents[hideallsubsections]\end{verbatim}
+%   use the following in \verb"\AtBeginSection"
+%   \begin{verbatim}\tableofcontents[currentsection, subsectionstyle=show/show/hide]\end{verbatim}
+%   and use the following in \verb"\AtBeginSubsection"
+%   \begin{verbatim}\tableofcontents[currentsection, subsectionstyle=show/shaded/hide]\end{verbatim}
+%    \begin{macrocode}
+\setbeamertemplate{sections/subsections in toc}[stamp]
+%    \end{macrocode}
+%  Remember, if you want to restore the theme to original TOC style, just use
+%  \begin{verbatim}\setbeamertemplate{sections/subsections in toc}[circle]\end{verbatim}
+%  or load \verb"circles" inner theme.
+%  \begin{verbatim}\useinnertheme{circles}\end{verbatim}
 %
 %  Patch beamer on \verb"itemize",\verb"enumerate",\verb"description" on the left margin.
 %    \begin{macrocode}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/16 v2.8.2 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/05/17 v2.8.3 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -853,6 +853,17 @@
 %</my>
 %    \end{macrocode}
 %
+%   \subsubsection{Table of Contents Style}
+%  
+%    \begin{macrocode}
+\defbeamertemplate{section in toc}{stamp}{
+    \leavevmode\leftskip=8mm\stamptext[cprimary]{\inserttocsectionnumber}\hspace{0.3em}
+    \inserttocsection\par\vspace{3pt}
+}
+\defbeamertemplate{subsection in toc}{stamp}{
+    \vspace{3pt}\leavevmode\leftskip=30mm\hspace{0.8em}\inserttocsubsection\par
+}
+%    \end{macrocode}
 %
 % \iffalse
 %</package>

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/16 v2.8.2 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/05/17 v2.8.3 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}
@@ -860,14 +860,14 @@
 %  Futhermore, the subsection doesn't even have a stamp marker so that the three-stage structure could not be formed to make use of all three-stage colors. Just all use one color to create a better look.
 %    \begin{macrocode}
 \defbeamertemplate{section in toc}{stamp}{
-    \leavevmode\leftskip=8mm\stamptext[structure]{\inserttocsectionnumber}\hspace{0.3em}
-    \inserttocsection\par\vspace{3pt}
+  \leavevmode\leftskip=8mm\stamptext[structure]{\inserttocsectionnumber}
+  \hspace{0.3em}\inserttocsection\par\vspace{3pt}
 }
 %    \end{macrocode}
 %  Define the \verb"stamp" TOC style for subsection in toc, notice that there is no \verb"\stamptext" in subsection to fit the style of \verb"circle" subsection in toc style, only with the additional left margin to align with (slightly right of) section in toc.
 %    \begin{macrocode}
 \defbeamertemplate{subsection in toc}{stamp}{
-    \vspace{3pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
+  \vspace{3pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
 }
 %    \end{macrocode}
 %

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -864,13 +864,15 @@
   \hspace{0.3em}\inserttocsection\par\vspace{3pt}
 }
 %    \end{macrocode}
-%  Define the \verb"stamp" TOC style for subsection in toc, notice that there is no \verb"\stamptext" in subsection to fit the style of \verb"circle" subsection in toc style, only with the additional left margin to align with (slightly right of) section in toc.
+%  Define the \verb"stamp" TOC style for subsection in toc, notice that there is no \verb"\stamptext" in subsection, in order to fit the style of \verb"circle" subsection in toc style, only with the additional left margin to align with (slightly right of) section in toc.
 %    \begin{macrocode}
 \defbeamertemplate{subsection in toc}{stamp}{
   \vspace{3pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
 }
 %    \end{macrocode}
-%  Define the \verb"stamp" TOC style for subsubsection in toc. Like it is in section in toc, only additional left margin is added with adaptation of the font style of subsubsection in toc.
+%  Define the \verb"stamp" TOC style for subsubsection in toc. Like it is in section in toc, only additional left margin is added with adaptation of the font style of subsubsection in toc. And subsubsection should never be used in beamer class, since there is no configuration for subsubsection in beamer to show. To control the visibility of subsubsection in toc,
+%  \begin{verbatim}\tableofcontents[subsubsectionstyle=hide]\end{verbatim}
+%  will hide all subsubsection in toc, since there is NO \verb"hideallsubsubsections" in beamer.
 %  COPYRIGHT NOTICE: reference to beamer class code with LPPL 1.3c License.
 %    \begin{macrocode}
 \defbeamertemplate{subsubsection in toc}{stamp}{

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -858,16 +858,18 @@
 %   Define the \verb"stamp" TOC style for section in toc. Just use the structure color of marker to match the color like the style in \verb"circle" section in toc.
 %  This may mismatch with the definition of \verb"section page" of \verb"max" theme. But it surely the same color with \verb"part page". Reducing the number of the color used is a correct choice.
 %  Futhermore, the subsection doesn't even have a stamp marker so that the three-stage structure could not be formed to make use of all three-stage colors. Just all use one color to create a better look.
+%  At the end of this section block, a thin vspace is added to avoid the collision between the subsection and the stamptext.
+%  Some space before this section block is added, since there may be some users use \verb"multicols" environment in package \verb"multicol" to make a split list of TOC (which is not recommended by the way). this space will help to avoid the collision between the section and the previous subsection.
 %    \begin{macrocode}
 \defbeamertemplate{section in toc}{stamp}{
-  \leavevmode\leftskip=8mm\stamptext[structure]{\inserttocsectionnumber}
-  \hspace{0.3em}\inserttocsection\par\vspace{3pt}
+  \vspace{2.5pt}\leavevmode\leftskip=8mm\stamptext[structure]{\inserttocsectionnumber}
+  \hspace{0.3em}\inserttocsection\par\vspace{0.5pt}
 }
 %    \end{macrocode}
-%  Define the \verb"stamp" TOC style for subsection in toc, notice that there is no \verb"\stamptext" in subsection, in order to fit the style of \verb"circle" subsection in toc style, only with the additional left margin to align with (slightly right of) section in toc.
+%  Define the \verb"stamp" TOC style for subsection in toc, notice that there is no \verb"\stamptext" in subsection, in order to fit the style of \verb"circle" subsection in toc style, only with the additional left margin to align with (slightly right of) section in toc. Add thin space at the start of every subsection in toc to add some line height.
 %    \begin{macrocode}
 \defbeamertemplate{subsection in toc}{stamp}{
-  \vspace{3pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
+  \vspace{1.5pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
 }
 %    \end{macrocode}
 %  Define the \verb"stamp" TOC style for subsubsection in toc. Like it is in section in toc, only additional left margin is added with adaptation of the font style of subsubsection in toc. And subsubsection should never be used in beamer class, since there is no configuration for subsubsection in beamer to show. To control the visibility of subsubsection in toc,

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -855,13 +855,19 @@
 %
 %   \subsubsection{Table of Contents Style}
 %  
+%   Define the \verb"stamp" TOC style for section in toc. Just use the structure color of marker to match the color like the style in \verb"circle" section in toc.
+%  This may mismatch with the definition of \verb"section page" of \verb"max" theme. But it surely the same color with \verb"part page". Reducing the number of the color used is a correct choice.
+%  Futhermore, the subsection doesn't even have a stamp marker so that the three-stage structure could not be formed to make use of all three-stage colors. Just all use one color to create a better look.
 %    \begin{macrocode}
 \defbeamertemplate{section in toc}{stamp}{
-    \leavevmode\leftskip=8mm\stamptext[cprimary]{\inserttocsectionnumber}\hspace{0.3em}
+    \leavevmode\leftskip=8mm\stamptext[structure]{\inserttocsectionnumber}\hspace{0.3em}
     \inserttocsection\par\vspace{3pt}
 }
+%    \end{macrocode}
+%  Define the \verb"stamp" TOC style for subsection in toc, notice that there is no \verb"\stamptext" in subsection to fit the style of \verb"circle" subsection in toc style, only with the additional left margin to align with (slightly right of) section in toc.
+%    \begin{macrocode}
 \defbeamertemplate{subsection in toc}{stamp}{
-    \vspace{3pt}\leavevmode\leftskip=30mm\hspace{0.8em}\inserttocsubsection\par
+    \vspace{3pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
 }
 %    \end{macrocode}
 %

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -870,6 +870,15 @@
   \vspace{3pt}\leavevmode\hspace{36mm}\inserttocsubsection\par
 }
 %    \end{macrocode}
+%  Define the \verb"stamp" TOC style for subsubsection in toc. Like it is in section in toc, only additional left margin is added with adaptation of the font style of subsubsection in toc.
+%  COPYRIGHT NOTICE: reference to beamer class code with LPPL 1.3c License.
+%    \begin{macrocode}
+\defbeamertemplate{subsubsection in toc}{stamp}{
+  \leavevmode\hspace{40mm}\normalsize\usebeamerfont{subsection in
+  toc}\usebeamerfont{subsubsection in toc}%
+  \inserttocsubsubsection\par
+}
+%    \end{macrocode}
 %
 % \iffalse
 %</package>

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/16 v2.8.2 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/05/17 v2.8.3 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/support/tutorial/step6+.tex
+++ b/src/support/tutorial/step6+.tex
@@ -3,7 +3,8 @@
 \begin{document}
 \begin{frame}
   \frametitle{目录}
-  \tableofcontents[hideallsubsections]
+  \tableofcontents
+  [hideallsubsections]
 \end{frame}
 \include{maincontents.tex}
 \end{document}

--- a/src/support/tutorial/step6+.tex
+++ b/src/support/tutorial/step6+.tex
@@ -3,7 +3,7 @@
 \begin{document}
 \begin{frame}
   \frametitle{目录}
-  \tableofcontents
+  \tableofcontents[hideallsubsections]
 \end{frame}
 \include{maincontents.tex}
 \end{document}

--- a/src/support/tutorial/step7+.tex
+++ b/src/support/tutorial/step7+.tex
@@ -3,7 +3,7 @@
 \begin{document}
 \AtBeginSubsection[]{
   \begin{frame}
-    \subsectionpage
+    \subsectionpage[currentsection, subsectionstyle=show/show/hide]
   \end{frame}
 }
 \include{maincontents.tex}

--- a/src/support/tutorial/step7+.tex
+++ b/src/support/tutorial/step7+.tex
@@ -3,7 +3,7 @@
 \begin{document}
 \AtBeginSubsection[]{
   \begin{frame}
-    \subsectionpage[currentsection, subsectionstyle=show/show/hide]
+    \subsectionpage
   \end{frame}
 }
 \include{maincontents.tex}

--- a/src/support/tutorial/step9+.tex
+++ b/src/support/tutorial/step9+.tex
@@ -4,7 +4,7 @@
 \AtBeginSection[]{
   \begin{frame}
     \tableofcontents
-    [currentsection]
+    [currentsection, subsectionstyle=show/shaded/hide]
   \end{frame}
 }
 \include{maincontents.tex}


### PR DESCRIPTION
采用新的目录样式。

||Before|After|
|---|---|---|
|总目录|<img width="376" alt="image" src="https://user-images.githubusercontent.com/61653082/168804176-f1b2e8f6-eb8f-46e3-bb8f-f1222bf502cb.png">|<img width="376" alt="image" src="https://user-images.githubusercontent.com/61653082/168804263-96b51ac8-1004-4d12-a91a-0bd268ac8a45.png">|
|节目录|<img width="376" alt="image" src="https://user-images.githubusercontent.com/61653082/168803129-a9133000-60f5-460b-9103-a1c0362c782c.png">|<img width="376" alt="image" src="https://user-images.githubusercontent.com/61653082/168803475-6dd8862b-9fc7-4f41-b9a2-70456a1e2056.png">|
|小节目录|<img width="376" alt="image" src="https://user-images.githubusercontent.com/61653082/168804420-51590baf-0aa7-4639-ac6d-81466a632636.png">|<img width="376" alt="image" src="https://user-images.githubusercontent.com/61653082/168804527-8dccc695-8bf9-4db9-b5fb-4e8ed605106b.png">|

推荐的目录配置已更新：
```latex
%% 所有目录
\begin{frame}
  \frametitle{目录}
  \tableofcontents[hideallsubsections]
\end{frame}
%% 节目录
\AtBeginSection[]{
\begin{frame}
  \tableofcontents[currentsection, subsectionstyle=show/show/hide]
\end{frame}
}
%% 小节目录
\AtBeginSubsection[]{
\begin{frame}
  \tableofcontents[currentsection, subsectionstyle=show/shaded/hide]
\end{frame}
}
```
甚至不推荐使用小节，会占据较大的纵向位置，并且在导航栏显示不明显。