### PR TITLE
docs: remove some packages temporarily

### DIFF
--- a/contents/basis.tex
+++ b/contents/basis.tex
@@ -25,7 +25,7 @@
             \item \pdfTeX{}：直接生成 PDF，支持 micro-typography
             \item \XeTeX{}：支持 Unicode、OpenType 与复杂文字编排（CTL）
             \item \LuaTeX{}：支持 Unicode，内联 Lua，支持 OpenType
-            \item (u)p\TeX{}：日本方面推动，生成 |.dvi|，（支持 Unicode）
+            \item (u)p\TeX{}：日本方面推动，生成 \verb|.dvi|，（支持 Unicode）
             \item Ap\TeX{}：底层 CJK 支持，内联 Ruby，Color Emoji
           \end{itemize}
 
@@ -53,17 +53,17 @@
     \item 命令行
 
           \begin{itemize}
-            \item |pdflatex|/|xelatex|/|lualatex| + |<文件名>[.tex]|
+            \item \verb|pdflatex|/\verb|xelatex|/\verb|lualatex| + \verb|<文件名>[.tex]|
             \item 多次编译：每次均需要读取并处理中间文件
-            \item 推荐 \pkg{latexmk}\footnote{\MiKTeX 用户需要自行安装 perl 解释器}：运行 |latexmk [<选项>] <文件名>| 即可自动完成所有工作
+            \item 推荐 \pkg{latexmk}\footnote{\MiKTeX 用户需要自行安装 perl 解释器}：运行 \verb|latexmk [<选项>] <文件名>| 即可自动完成所有工作
           \end{itemize}
 
     \item 编辑器
 
           \begin{itemize}
             \item 按钮的背后仍然是命令
-            \item |PATH| 环境变量：确定可执行文件的位置
-            \item VS Code + \LaTeX{} Workshop：配置 |tools| 和 |recipes|
+            \item \verb|PATH| 环境变量：确定可执行文件的位置
+            \item VS Code + \LaTeX{} Workshop：配置 \verb|tools| 和 \verb|recipes|
           \end{itemize}
   \end{itemize}
 \end{frame}
@@ -270,7 +270,7 @@ V = \frac{4}{3}\pi r^3
 %               \end{equation*}
 %             \end{column}
 %           \end{columns}
-%     \item 使用 |symbf| 等命令自动处理字母的粗体、斜体等变体，不必引入额外宏包。
+%     \item 使用 \verb|symbf| 等命令自动处理字母的粗体、斜体等变体，不必引入额外宏包。
 %   \end{itemize}
 
 %   \begin{columns}[c]
@@ -365,9 +365,9 @@ V = \frac{4}{3}\pi r^3
 \begin{frame}[fragile]{交叉引用与插入插图}
   \begin{itemize}
     \item 给对象命名：图片、表格、公式等\\
-          |\label{name}|
+          \verb|\label{name}|
     \item 引用对象\\
-          |\ref{name}|
+          \verb|\ref{name}|
   \end{itemize}
   \bigskip
 
@@ -427,12 +427,12 @@ V = \frac{4}{3}\pi r^3
   \begin{itemize}
     \item 初学者最“捉摸不透”的特性之一 \link{https://liam.page/2017/03/11/floats-in-LaTeX-basic}
     \item 图片和表格有时会很大，在插入的位置不一定放得下，因此需要浮动调整
-    \item 避免在文中使用「下图」「上图」的说法，而是使用图表的编号，例如 |图~\ref{fig:fig1}| 。
-    \item |\begin{figure}[<位置>] 图片 \end{figure}|
+    \item 避免在文中使用「下图」「上图」的说法，而是使用图表的编号，例如 \verb|图~\ref{fig:fig1}| 。
+    \item \verb|\begin{figure}[<位置>] 图片 \end{figure}|
           \begin{itemize}
             \item 位置参数指定浮动体摆放的偏好
-            \item |h| 当前位置(here), |t| 顶部(top), |b| 底部(bottom), |p| 单独成页(p)
-            \item |!h| 表示忽略一些限制，|H| 表示强制\alert{（强烈不建议，除非你知道自己在做什么）}
+            \item \verb|h| 当前位置(here), \verb|t| 顶部(top), \verb|b| 底部(bottom), \verb|p| 单独成页(p)
+            \item \verb|!h| 表示忽略一些限制，\verb|H| 表示强制\alert{（强烈不建议，除非你知道自己在做什么）}
           \end{itemize}
     \item 温馨提示：图标题一般在下方，表标题一般在上方
   \end{itemize}
@@ -460,10 +460,10 @@ V = \frac{4}{3}\pi r^3
     \item 插图格式
 
           \begin{itemize}
-            \item 矢量图：|.pdf|
-            \item 位图：|.jpg| 或 |.png|
+            \item 矢量图：\verb|.pdf|
+            \item 位图：\verb|.jpg| 或 \verb|.png|
             \item \alert{不再推荐 \texttt{.eps}}
-            \item 不（完全）支持 |.svg|、|.bmp|
+            \item 不（完全）支持 \verb|.svg|、\verb|.bmp|
           \end{itemize}
 
     \item 一些参考：\link{https://www.zhihu.com/question/21664179}
@@ -616,11 +616,11 @@ V = \frac{4}{3}\pi r^3
     \begin{itemize}
       \item 获取模板：已随发行版自带
             \begin{itemize}
-              \item 在安装目录 |<prefix>\texlive\2021\texmf-dist\doc\latex\IEEEtran|
-                    下找到 |bare_jrnl.tex|
+              \item 在安装目录 \verb|<prefix>\texlive\2021\texmf-dist\doc\latex\IEEEtran|
+                    下找到 \verb|bare_jrnl.tex|
               \item 复制到某个文件夹(比如个人存论文的目录)
             \end{itemize}
-      \item 编辑 |bare_jrnl.tex| 文件 (英文模板：不支持中文)
+      \item 编辑 \verb|bare_jrnl.tex| 文件 (英文模板：不支持中文)
       \item 编译
             \begin{itemize}
               \item 英文文献：\XeLaTeX{}、\pdfLaTeX{} 编译均可

--- a/contents/basis.tex
+++ b/contents/basis.tex
@@ -246,49 +246,51 @@ V = \frac{4}{3}\pi r^3
   \end{itemize}
 \end{frame}
 
-\begin{frame}[fragile,label={frame:unicode-math}]{unicode-math：现代的数学输入方式}
-  \LaTeX{} 的公式确实很强大，但是……符号有点难记？
+%% 需要在导言区使用 \usepackage{unicode-math}
+%
+% \begin{frame}[fragile,label={frame:unicode-math}]{unicode-math：现代的数学输入方式}
+%   \LaTeX{} 的公式确实很强大，但是……符号有点难记？
 
-  \pkg{unicode-math} 宏包提供了几乎所见即所得的公式输入：
+%   \pkg{unicode-math} 宏包提供了几乎所见即所得的公式输入：
 
-  \begin{itemize}
-    \item 可直接输入各类符号对应的 Unicode 字符（需要使用 UTF-8 编码）：
+%   \begin{itemize}
+%     \item 可直接输入各类符号对应的 Unicode 字符（需要使用 UTF-8 编码）：
 
-          \begin{columns}[c]
-            \begin{column}{0.45\textwidth}
-              \begin{lstlisting}
-\begin{equation*}
-∫ Γ(x) dx = ±∞
-\end{equation*}
-      \end{lstlisting}
-            \end{column}\hspace{1em}
-            \begin{column}{0.45\textwidth}
-              \begin{equation*}
-                ∫ Γ(x) dx = ±∞
-              \end{equation*}
-            \end{column}
-          \end{columns}
-    \item 使用 |symbf| 等命令自动处理字母的粗体、斜体等变体，不必引入额外宏包。
-  \end{itemize}
+%           \begin{columns}[c]
+%             \begin{column}{0.45\textwidth}
+%               \begin{lstlisting}
+% \begin{equation*}
+% ∫ Γ(x) dx = ±∞
+% \end{equation*}
+%       \end{lstlisting}
+%             \end{column}\hspace{1em}
+%             \begin{column}{0.45\textwidth}
+%               \begin{equation*}
+%                 ∫ Γ(x) dx = ±∞
+%               \end{equation*}
+%             \end{column}
+%           \end{columns}
+%     \item 使用 |symbf| 等命令自动处理字母的粗体、斜体等变体，不必引入额外宏包。
+%   \end{itemize}
 
-  \begin{columns}[c]
-    \begin{column}{0.45\textwidth}
-      \begin{lstlisting}
-\begin{align*}
-\symbf{\beta} &= \beta \symbf{I} \\
-\symbf{a} &= a \symbf{I}
-\end{align*}
-\end{lstlisting}
-    \end{column}\hspace{1em}
-    \begin{column}{0.45\textwidth}
-      \begin{align*}
-        \symbf{\beta} & = \beta \symbf{I} \\
-        \symbf{a}     & = a \symbf{I}
-      \end{align*}
-    \end{column}
-  \end{columns}
+%   \begin{columns}[c]
+%     \begin{column}{0.45\textwidth}
+%       \begin{lstlisting}
+% \begin{align*}
+% \symbf{\beta} &= \beta \symbf{I} \\
+% \symbf{a} &= a \symbf{I}
+% \end{align*}
+% \end{lstlisting}
+%     \end{column}\hspace{1em}
+%     \begin{column}{0.45\textwidth}
+%       \begin{align*}
+%         \symbf{\beta} & = \beta \symbf{I} \\
+%         \symbf{a}     & = a \symbf{I}
+%       \end{align*}
+%     \end{column}
+%   \end{columns}
 
-\end{frame}
+% \end{frame}
 
 \begin{frame}[fragile]{层次与目录生成}
   \begin{columns}

--- a/contents/introduction.tex
+++ b/contents/introduction.tex
@@ -299,7 +299,7 @@
   \begin{itemize}
     \item Windows
           \begin{itemize}
-            \item 挂载或解压下载的 ISO，运行 |install-tl-windows.bat|
+            \item 挂载或解压下载的 ISO，运行 \verb|install-tl-windows.bat|
             \item 切换默认仓库为国内镜像（如 SJTUG）可加速今后升级
           \end{itemize}
     \item macOS
@@ -379,9 +379,9 @@ export INFOPATH=/usr/local/texlive/2021/texmf/doc/info:$INFOPATH
           \end{itemize}
     \item \TL
           \begin{itemize}
-            \item 设置仓库地址 |tlmgr option repository| {\footnotesize\ttfamily
+            \item 设置仓库地址 \verb|tlmgr option repository| {\footnotesize\ttfamily
                   https://mirrors.sjtug.sjtu.edu.cn/CTAN/systems/texlive/tlnet}
-            \item |tlmgr install <pkgname>| 安装、 |tlmgr update --self --all| 全部更新
+            \item \verb|tlmgr install <pkgname>| 安装、 \verb|tlmgr update --self --all| 全部更新
             \item \faWindows{} 开始菜单里找 TeX Live Manager
           \end{itemize}
     \item \MiKTeX

--- a/contents/summary.tex
+++ b/contents/summary.tex
@@ -69,9 +69,9 @@
           \end{itemize}
     \item 工具
           \begin{itemize}
-            \item |tlmgr|: \TL 管理器
-            \item |texdoc|: \TeX{} 文档查看器\\
-                  例如：|texdoc lshort-zh-cn|
+            \item \verb|tlmgr|: \TL 管理器
+            \item \verb|texdoc|: \TeX{} 文档查看器\\
+                  例如：\verb|texdoc lshort-zh-cn|
             \item 在线文档 \TeX{}doc \link{http://texdoc.net/}
             \item TeX Studio 和 WinEdt 都支持在帮助里看文档
           \end{itemize}
@@ -106,10 +106,10 @@
           \end{itemize}
     \item 基本用法
           \begin{itemize}
-            \item 跟踪更改：|git init|、|git add|、|git commit|
-            \item 撤销与回滚：|git reset|、|git revert|
-            \item 分支与高级用法：|git branch|、|git checkout|、|git rebase|
-            \item 远端仓库操作：|git pull|、|git push|、|git fetch|
+            \item 跟踪更改：\verb|git init|、\verb|git add|、\verb|git commit|
+            \item 撤销与回滚：\verb|git reset|、\verb|git revert|
+            \item 分支与高级用法：\verb|git branch|、\verb|git checkout|、\verb|git rebase|
+            \item 远端仓库操作：\verb|git pull|、\verb|git push|、\verb|git fetch|
             \item 推荐用 VS Code 等进行可视化操作
             \item 参考链接：\link{https://git-scm.com/book/en/v2}
                   \link{https://www.liaoxuefeng.com/wiki/0013739516305929606dd18361248578c67b8067c8c017b000}

--- a/contents/thesis.tex
+++ b/contents/thesis.tex
@@ -189,12 +189,14 @@
           \begin{itemize}
             \item 参考文献列表出错、缺少字体、无法编译、格式不对……
             \item 阅读模板文档 \verb|sjtuthesis.pdf| 和 SJTUThesis 示例文档代码
-            \item 查看 FAQ \link{https://github.com/sjtug/SJTUThesis/wiki/常见问题}
+            \item 查看 Wiki \link{https://github.com/sjtug/SJTUThesis/wiki}
           \end{itemize}
+
     \item 主动提问
           \begin{itemize}
             \item GitHub Discussions 提问：\link{https://github.com/sjtug/SJTUThesis/discussions}
             \item GitHub Issues 报告 BUG：\link{https://github.com/sjtug/SJTUThesis/issues}
           \end{itemize}
+
   \end{itemize}
 \end{frame}

--- a/contents/thesis.tex
+++ b/contents/thesis.tex
@@ -44,16 +44,16 @@
         \item 下载最新开发版（高级 / 想尝鲜 / 着急的用户）
               \begin{itemize}
                 \item \url{https://github.com/sjtug/SJTUThesis}
-                \item 切换到 |develop| 分支，点右边栏
+                \item 切换到 \verb|develop| 分支，点右边栏
                       \href{https://github.com/sjtug/SJTUThesis/archive/dev.zip}%
                       {Download ZIP} 按钮
               \end{itemize}
         \item 编译
               \begin{itemize}
-                \item 解压缩看文档 |README.md|
-                \item Windows: 双击 |Compile.bat| 脚本编译
-                \item Linux \& macOS: 使用 |Makefile|
-                \item 使用 |latexmk -xelatex main|
+                \item 解压缩看文档 \verb|README.md|
+                \item Windows: 双击 \verb|Compile.bat| 脚本编译
+                \item Linux \& macOS: 使用 \verb|Makefile|
+                \item 使用 \verb|latexmk -xelatex main|
               \end{itemize}
       \end{itemize}
     \end{column}
@@ -77,7 +77,7 @@
       \begin{lstlisting}[basicstyle=\ttfamily]
 \documentclass[type=master,review]{sjtuthesis}
   \end{lstlisting}
-    \item[fontset] 指定字体（推荐使用 |windows|）
+    \item[fontset] 指定字体（推荐使用 \verb|windows|）
       \begin{lstlisting}[basicstyle=\ttfamily]
 \documentclass[type=doctor,fontset=windows]{sjtuthesis}
   \end{lstlisting}
@@ -85,7 +85,7 @@
 \end{frame}
 
 \begin{frame}[fragile]{模板设置}
-  使用 |\sjtusetup| 命令指定论文各类设置：
+  使用 \verb|\sjtusetup| 命令指定论文各类设置：
   \begin{lstlisting}
 \sjtusetup{
   info = {
@@ -105,20 +105,20 @@
 \end{frame}
 
 \begin{frame}[fragile]{信息录入}
-  |info| 域完成论文基本信息录入
+  \verb|info| 域完成论文基本信息录入
   \begin{table}[h]
     \centering
     \footnotesize
     \begin{tabular}{lll} \toprule
       命令作用     & 中文对应选项                      & 英文对应选项      \\ \midrule
-      论文标题     & |title|                           & |title*|          \\
-      关键字列表   & |keywords|                        & |keywords*|       \\
-      作者姓名     & |author|                          & |author*|         \\
-      申请学位名称 & |degree|                          & |degree*|         \\
-      院系名称     & |department|                      & |department*|     \\
-      专业名称     & |major|                           & |major*|          \\
-      导师         & |supervisor|                      & |supervisor*|     \\
-      副导师       & |assisupervisor|                  & |assisupervisor*| \\
+      论文标题     & \verb|title|                           & \verb|title*|          \\
+      关键字列表   & \verb|keywords|                        & \verb|keywords*|       \\
+      作者姓名     & \verb|author|                          & \verb|author*|         \\
+      申请学位名称 & \verb|degree|                          & \verb|degree*|         \\
+      院系名称     & \verb|department|                      & \verb|department*|     \\
+      专业名称     & \verb|major|                           & \verb|major*|          \\
+      导师         & \verb|supervisor|                      & \verb|supervisor*|     \\
+      副导师       & \verb|assisupervisor|                  & \verb|assisupervisor*| \\
       日期         & \multicolumn{2}{c}{\texttt{date}}                     \\
       学号         & \multicolumn{2}{c}{\texttt{id}}                       \\ \bottomrule
     \end{tabular}
@@ -128,7 +128,7 @@
 \begin{frame}[fragile]{数学}
   \begin{itemize}
     \item 公式示例：\nolinkurl{contents/math_and_citations.tex}
-    \item \SJTUThesis{} 定义了常用的数学环境（需要手工引入 |amsthm| 宏包）：
+    \item \SJTUThesis{} 定义了常用的数学环境（需要手工引入 \verb|amsthm| 宏包）：
           \begin{table}[h]
             \centering
             \footnotesize
@@ -154,7 +154,7 @@
             \item 控制文献、引用样式：\pkg{natbib} 宏包
             \item 国标样式：\pkg{gbt7714} 宏包 \link{https://mirrors.sjtug.sjtu.edu.cn/ctan/biblio/bibtex/contrib/gbt7714/gbt7714.pdf}
           \end{itemize}
-    \item 现代方法：|biber| 后端 + \pkg{biblatex} 宏包
+    \item 现代方法：\verb|biber| 后端 + \pkg{biblatex} 宏包
           \begin{itemize}
             \item 国标样式：\pkg{biblatex-gbt7714-2015} 宏包 \link{https://mirrors.sjtug.sjtu.edu.cn/ctan/macros/latex/contrib/biblatex-contrib/biblatex-gb7714-2015/biblatex-gb7714-2015.pdf}
           \end{itemize}
@@ -164,7 +164,7 @@
 
 \begin{frame}[fragile]{参考文献（续）}
   \begin{itemize}
-    \item 生成 |.bib| 数据库
+    \item 生成 \verb|.bib| 数据库
           \begin{itemize}
             \item Google Scholar 可直接复制或者批量导出
             \item 用 Zotero、Jabref 等文献管理软件生成
@@ -188,7 +188,7 @@
     \item 常见问题
           \begin{itemize}
             \item 参考文献列表出错、缺少字体、无法编译、格式不对……
-            \item 阅读模板文档 |sjtuthesis.pdf| 和 SJTUThesis 示例文档代码
+            \item 阅读模板文档 \verb|sjtuthesis.pdf| 和 SJTUThesis 示例文档代码
             \item 查看 FAQ \link{https://github.com/sjtug/SJTUThesis/wiki/常见问题}
           \end{itemize}
     \item 主动提问

--- a/main.tex
+++ b/main.tex
@@ -21,7 +21,6 @@
 \usepackage{amsmath}
 \usepackage{mflogo}
 \usepackage{graphicx}
-\usepackage{unicode-math}
 \usepackage{ccicons}
 \usepackage{hologo}
 \usepackage{colortbl}

--- a/main.tex
+++ b/main.tex
@@ -97,12 +97,6 @@
   breaklines=true,
 }
 
-\lstdefinestyle{style@inline}{
-  basicstyle   = \ttfamily,
-  keepspaces   = true
-}
-\lstMakeShortInline[style=style@inline]|
-
 \usetheme[maxplus]{sjtubeamer}
 % 使用 maxplus/max/min 切换标题页样式
 % 使用 red/blue 切换主色调


### PR DESCRIPTION
- 在没有字体配置功能前，暂时去除主文档中的 `unicode-math` 宏包引用，暂时部分解决 #109
- 去除行内抄录（应当使用 `\verb|SOMETHING|` 而不使用省略版的 `|SOMETHING|`），以避免与绝对值输入的冲突，此时 `frame` 上仍然应当有 `fragile` 选项
- 不使用 `biblatex` 时，主文档可以使用 pdflatex 编译（使用 `gbt7714` 时，pdflatex 编译需要路径全英文）