### PR TITLE
refactor: secondary institute logo

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -227,6 +227,12 @@
 		"body": "\\definelogo[${1:vi}]{$2}{$3}{$4}",
 		"description": "Define a mask picture to make its different color variants.\nThe first argument assigns the file name and the second sets the horizontal cropping and the third sets the vertical cropping. Notice that the cropping is symmetrical (double the length). When the horizontal cropping is greater than the vertical cropping, the mask will be placed by its height, otherwise by its width. The domain for both cropping parameters is 0 to 1.\nYou should define a logo \\definelogo{mylogo}{<hc>}{<vc>} then use it in the contents like:\n\\mylogo[white], where the optional parameter could be the override color beyond the control of main logo color system or opacity=... to identify the opacity you want or any other parameter for a TikZ node.\nRemember, the picture should be in the vi/ folder by default. If you want to use some other file in other folder, add an optional paramter like \\definelogo[folder]{file}{0}{0} will get the folder/file.\nThe externalization will be disabled when using this system to generate logos, locally.\n"
 	},
+	"secondaryinstlogo": {
+		"scope": "doctex,tex,latex",
+		"prefix": "\\secondaryinstlogo",
+		"body": "\\secondaryinstlogo{$1}",
+		"description": "Logo with secondary institute.\nThe first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name.\nThe macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \\\\.\nThe second mandantory parameter is the main name for your institute.\nThe third parameter is the logo of the left side, you could leave it as empty but mandantory.\nBy default, this combination will occupy the whole row.\n"
+	},
 	"stamptext": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\stamptext",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -230,7 +230,7 @@
 	"secondaryinstlogo": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\secondaryinstlogo",
-		"body": "\\secondaryinstlogo{$1}",
+		"body": "\\secondaryinstlogo[${1:}]{$2}{$3}",
 		"description": "Logo with secondary institute.\nThe first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name.\nThe macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \\\\.\nThe second mandantory parameter is the main name for your institute.\nThe third parameter is the logo of the left side, you could leave it as empty but mandantory.\nBy default, this combination will occupy the whole row.\n"
 	},
 	"stamptext": {

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}
@@ -42,7 +42,7 @@
   \AtBeginDocument{
     \defbeamertemplate*{frametitle}{sjtubeamer}[1][]
     {%
-    \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+      \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
       \@tempdima=\textwidth%
       \advance\@tempdima by\beamer@leftmargin%
       \advance\@tempdima by\beamer@rightmargin%
@@ -70,7 +70,7 @@
         \begingroup
         \ifx\insertframesubtitle\@empty\vskip-2.3ex%
         \else\vskip-3.0ex\fi%
-        \resizebox{!}{0.7cm}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{5pt}%
+        \resizebox{!}{0.7cm}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{10pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
         \else\vskip0.6ex\fi%

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/18 v2.9.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/07/19 v2.9.1 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}
@@ -69,7 +69,7 @@
         {\usebeamercolor[fg]{institute}\small\insertinstitute\par}
         {\usebeamercolor[fg]{date}\small\insertdate}%
     };
-    \node[anchor=south east, inner sep=0, outer sep=0] at (\outslant,0.5){
+    \node[anchor=south east, inner sep=0, outer sep=0] at ({\outslant-5pt},0.5){
       \usebeamercolor[fg]{palatte primary}
       \resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}
     };
@@ -151,42 +151,17 @@
   \vfill
   \begingroup
   \centering
-  \begin{beamercolorbox}{empty}
-    \usebeamercolor[fg]{palette primary}
+  \begin{beamercolorbox}[sep=0pt,#1]{empty}
     \vskip8pt
-    \hbox{
-      \hskip-4pt{\resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}}
-      \ifx\insertinstitute\@empty%
-      \else
-      \ifx\insertlogo\@empty%
-        \else
-        {\hskip0pt\vrule width0.5pt}\hskip0pt
-      \fi
-      \if\EqualOption{inner}{lang}{en}
-      \vbox to 1cm{
-          \vfill
-          \vbox{
-            \offinterlineskip
-            \noindent \strut
-            \baselineskip 0pt \lineskip -2pt
-            \scriptsize\textsc{\beamer@shortinstitute}
-            \strut
-          }
-          \vfill
-        }
-      \else
-      \hskip3pt\vbox{
-        \fontsize{13pt}{0pt}\selectfont
-        \insertinstitute
-        \par\noindent\vskip0.14em
-        \fontsize{5pt}{0pt}\selectfont
-        \textsc{\insertshortinstitute}
-        \baselineskip 3.9pt
-        \par~
-      }
-      \fi
-      \fi%
-    }
+    \hfuzz=130pt%
+    \usebeamercolor[fg]{palette primary}%
+    \if\EqualOption{inner}{lang}{en}%
+      \hspace*{8pt}%
+      \secondaryinstlogo{\beamer@shortinstitute}{\usebeamertemplate{logo}}
+    \else%
+      \hspace*{8pt}%
+      \secondaryinstlogo[\insertshortinstitute]{\insertinstitute}{\usebeamertemplate{logo}}
+    \fi%
     \vskip8pt
   \end{beamercolorbox}
   \begin{beamercolorbox}[sep=8pt,#1]{title}
@@ -267,7 +242,7 @@
         \node[white] at (-0.45\paperwidth,0.3\paperheight)
         {\resizebox{!}{0.115\paperheight}{\vphantom{-}\usebeamertemplate{logo}}};
         \node [right, white] at (-0.75\paperwidth, 0.15\paperheight)
-        {\resizebox{1.25\paperwidth}{!}{\sjtugate}};
+        {\resizebox{1.15\paperwidth}{!}{\sjtugate}};
       \end{scope}
       \node at (-0.13\paperwidth,0.7\paperheight) {
         \usebeamercolor[fg]{title}
@@ -420,7 +395,7 @@
     \fill [bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
     rectangle (1*\the\paperwidth, 0.4*\the\paperheight);
     \node [right, fg] at (-0.2*\the\paperwidth, -0.5*\the\paperheight)
-    {\resizebox{1.25\paperwidth}{!}{\sjtugate}};
+    {\resizebox{1.15\paperwidth}{!}{\sjtugate}};
   \end{tikzpicture}
   \vfil
   \begingroup

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/18 v2.9.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/07/19 v2.9.1 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{
   % #1: package
   % #2: key
@@ -66,16 +66,15 @@
       \node {\includegraphics[height=1.5cm]{#1/#2}};
     \end{tikzfadingfrompicture}
   \fi
-  \expandafter\providecommand\csname #2\endcsname[1][]{
+  \expandafter\providecommand\csname #2\endcsname[1][]{%
     % ##1: override color, or opacity=... (optional)
-    \tikzexternaldisable
-    \begin{tikzpicture}
+    \tikzexternaldisable%
+    \begin{tikzpicture}%
       \begin{scope}
         \clip ({-1.0+#3},{-1.0+#4}) rectangle ({1.0-#3},{1.0-#4});
-        \fill [##1, path fading=#2]
-          (-1,-1) rectangle (1,1);
+        \fill [##1, path fading=#2] (-1,-1) rectangle (1,1);
       \end{scope}
-    \end{tikzpicture}
+    \end{tikzpicture}%
   }
 }
 \definelogo{sjtubadge}{0}{0}
@@ -85,6 +84,46 @@
 \definelogo{vlogo}{0.8}{0.13}
 \definelogo{sjtubg}{0.3}{0.5}
 \definelogo{sjtugate}{0.25}{0.8}
+\newcommand*{\secondaryinstlogo}[3][]{%
+  % #1: shortinst (optional)
+  % #2: longinst
+  % #3: logo
+  \def\shortinst{#1}%
+  \def\longinst{#2}%
+  \def\mylogo{#3}%
+  \hbox{%
+    \raggedright%
+    \resizebox{!}{1cm}{\vphantom{-}#3}%
+    \ifx\longinst\@empty%
+    \else%
+      \ifx\shortinst\@empty%
+        \ifx\mylogo\@empty\else%
+          {\hskip0.31cm\vrule width0.5pt}\hskip0.31cm%
+        \fi%
+        \vbox to 1cm{%
+          \vfill%
+          \baselineskip 0pt\lineskip 2pt%
+          \noindent%
+          \fontsize{7.5pt}{0pt}\selectfont\scshape #2%
+          \vfill%
+        }%
+      \else%
+        \ifx\mylogo\@empty\else%
+          {\hskip0.23cm\vrule width0.5pt}\hskip0.23cm%
+        \fi%
+        \vbox{%
+          \fontsize{13pt}{0pt}\selectfont
+          \sffamily #2
+          \par\noindent\vskip0.14em
+          \fontsize{5pt}{0pt}\selectfont
+          \scshape #1
+          \baselineskip 3.9pt
+          \par~
+        }%
+      \fi
+    \fi
+  }
+}
 \providecommand{\stamptext}[2][structure]{
   {
     \providecolor{#1}{named}{sjtuRedPrimary}

--- a/src/build.lua
+++ b/src/build.lua
@@ -194,7 +194,7 @@ function gen_snippets()
                 -- Find TeX style definition, see Coding Style 3.1.2
                 local def_param = string.match(line, "\\def" .. in_macro .. "([#%d]*)")
                 -- Find LaTeX style definition, see Coding Style 3.1.3
-                local comm_decl, comm_param, param_default = string.match(line, "\\(%a+<?>?){" .. in_macro .. "}%[?(%d?)%]?(%[?%a*@*\\*%]?)")
+                local comm_decl, comm_param, param_default = string.match(line, "\\(%a+<?>?%*?){" .. in_macro .. "}%[?(%d?)%]?(%[?%a*@*\\*%]?)")
                 if def_param ~= nil then
                     def_param = string.gsub(def_param, "#(%d)", "{$%1}")
                     macro_body = macro_body .. "\\" .. in_macro .. def_param

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -1,8 +1,7 @@
 \documentclass{ltxdoc}
 \usepackage[scheme=plain]{ctex}
-\usepackage[colorlinks]{hyperref}
-\usepackage[numbers, sort&compress]{natbib}
-\bibliographystyle{IEEEtran}
+\usepackage[style=ieee]{biblatex}
+\addbibresource{dev.bib}
 \usepackage{array}
 \usepackage{tcolorbox}
 \tcbuselibrary{skins}
@@ -34,6 +33,7 @@
 \usepackage{multicol}
 \usepackage{tikz}
 \usepackage{hologo}
+\usepackage[colorlinks]{hyperref}
 
 \def\fcmd#1{\paragraph{\fbox{\ttfamily #1}}}
 
@@ -741,6 +741,7 @@ More details about this experimental caching mechanism in \texttt{l3build doc}, 
 \DocInput{sjtuvi.dtx}
 
 \clearpage
-\bibliography{dev}
+
+\printbibliography
 
 \end{document}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -110,7 +110,7 @@
 %    \end{macrocode}
 % Insert the outer logo with 0.7cm height. \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input. The calculation is fixed for a 0.7cm height logo placeholder.
 %    \begin{macrocode}
-        \resizebox{!}{0.7cm}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{5pt}%
+        \resizebox{!}{0.7cm}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{10pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
         \else\vskip0.6ex\fi%

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -79,7 +79,7 @@
   \AtBeginDocument{
     \defbeamertemplate*{frametitle}{sjtubeamer}[1][]
     {%
-    \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
+      \ifbeamercolorempty[bg]{frametitle}{}{\nointerlineskip}%
       \@tempdima=\textwidth%
       \advance\@tempdima by\beamer@leftmargin%
       \advance\@tempdima by\beamer@rightmargin%

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/05/18 v2.9.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -245,15 +245,22 @@
 %   \verb"resizebox" is used to adapt to all size of logo into 1cm height one. And it is the same in outer theme to make a 0.7cm logo. 
 %   The institute is in \TeX{} code for typesetting. \verb"\beamer@shortinstitute" meta is used to avoid compressing on \verb"\par", while \verb"\insertinstitute" will force the input to spread on one signle line. The mode to use is depended on the \verb"language" option. Super small font could be made by \verb"fontsize".
 %   Here, we use the option from inner to get the language setting, if this package is used independently, only chinese mode is available.
+%   FIXME: There is some bug when using EqualOption with the secondaryinstlogo. hskip is not working properly, and is placed inside the condition test.
 %    \begin{macrocode}
-  \begin{beamercolorbox}[sep=8pt,#1]{empty}
-    \usebeamercolor[fg]{palette primary}
-    \if\EqualOption{inner}{lang}{en}
+  \vskip8pt
+  \begin{beamercolorbox}[sep=0pt,#1]{empty}
+    \raggedright%
+    \hfuzz=130pt%
+    \usebeamercolor[fg]{palette primary}%
+    \if\EqualOption{inner}{lang}{en}%
+      \hspace*{8pt}%
       \secondaryinstlogo{\beamer@shortinstitute}{\usebeamertemplate{logo}}
-    \else
+    \else%
+      \hspace*{8pt}%
       \secondaryinstlogo[\insertshortinstitute]{\insertinstitute}{\usebeamertemplate{logo}}
-    \fi
+    \fi%
   \end{beamercolorbox}
+  \vskip8pt
 %    \end{macrocode}
 %   Insert title, subtitle, author, and date.
 %    \begin{macrocode}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -247,8 +247,8 @@
 %   Here, we use the option from inner to get the language setting, if this package is used independently, only chinese mode is available.
 %   FIXME: There is some bug when using EqualOption with the secondaryinstlogo. hskip is not working properly, and is placed inside the condition test.
 %    \begin{macrocode}
-  \vskip8pt
   \begin{beamercolorbox}[sep=0pt,#1]{empty}
+    \vskip8pt
     \raggedright%
     \hfuzz=130pt%
     \usebeamercolor[fg]{palette primary}%
@@ -259,8 +259,8 @@
       \hspace*{8pt}%
       \secondaryinstlogo[\insertshortinstitute]{\insertinstitute}{\usebeamertemplate{logo}}
     \fi%
+    \vskip8pt
   \end{beamercolorbox}
-  \vskip8pt
 %    \end{macrocode}
 %   Insert title, subtitle, author, and date.
 %    \begin{macrocode}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -127,7 +127,7 @@
         {\usebeamercolor[fg]{institute}\small\insertinstitute\par}
         {\usebeamercolor[fg]{date}\small\insertdate}%
     };
-    \node[anchor=south east, inner sep=0, outer sep=0] at (\outslant,0.5){
+    \node[anchor=south east, inner sep=0, outer sep=0] at ({\outslant-5pt},0.5){
       \usebeamercolor[fg]{palatte primary}
       \resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}
     };
@@ -246,15 +246,13 @@
 %   The institute is in \TeX{} code for typesetting. \verb"\beamer@shortinstitute" meta is used to avoid compressing on \verb"\par", while \verb"\insertinstitute" will force the input to spread on one signle line. The mode to use is depended on the \verb"language" option. Super small font could be made by \verb"fontsize".
 %   Here, we use the option from inner to get the language setting, if this package is used independently, only chinese mode is available.
 %    \begin{macrocode}
-  \begin{beamercolorbox}{empty}
+  \begin{beamercolorbox}[sep=8pt,#1]{empty}
     \usebeamercolor[fg]{palette primary}
-    \vskip8pt
     \if\EqualOption{inner}{lang}{en}
       \secondaryinstlogo{\beamer@shortinstitute}{\usebeamertemplate{logo}}
     \else
       \secondaryinstlogo[\insertshortinstitute]{\insertinstitute}{\usebeamertemplate{logo}}
     \fi
-    \vskip8pt
   \end{beamercolorbox}
 %    \end{macrocode}
 %   Insert title, subtitle, author, and date.
@@ -362,7 +360,7 @@
         \node[white] at (-0.45\paperwidth,0.3\paperheight)
         {\resizebox{!}{0.115\paperheight}{\vphantom{-}\usebeamertemplate{logo}}};
         \node [right, white] at (-0.75\paperwidth, 0.15\paperheight) 
-        {\resizebox{1.25\paperwidth}{!}{\sjtugate}};
+        {\resizebox{1.15\paperwidth}{!}{\sjtugate}};
       \end{scope}
       \node at (-0.13\paperwidth,0.7\paperheight) {
         \usebeamercolor[fg]{title}
@@ -609,7 +607,7 @@
     \fill [bg] (-0.2*\the\paperwidth,-1*\the\paperheight)
     rectangle (1*\the\paperwidth, 0.4*\the\paperheight);
     \node [right, fg] at (-0.2*\the\paperwidth, -0.5*\the\paperheight)
-    {\resizebox{1.25\paperwidth}{!}{\sjtugate}};
+    {\resizebox{1.15\paperwidth}{!}{\sjtugate}};
   \end{tikzpicture}
   \vfil
   \begingroup

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -245,11 +245,10 @@
 %   \verb"resizebox" is used to adapt to all size of logo into 1cm height one. And it is the same in outer theme to make a 0.7cm logo. 
 %   The institute is in \TeX{} code for typesetting. \verb"\beamer@shortinstitute" meta is used to avoid compressing on \verb"\par", while \verb"\insertinstitute" will force the input to spread on one signle line. The mode to use is depended on the \verb"language" option. Super small font could be made by \verb"fontsize".
 %   Here, we use the option from inner to get the language setting, if this package is used independently, only chinese mode is available.
-%   FIXME: There is some bug when using EqualOption with the secondaryinstlogo. hskip is not working properly, and is placed inside the condition test.
+%   Set \verb"\hfuzz" to 130pt to avoid the overfull hbox warning, the \verb"\hspace" should be placed in the branch body to make it work.
 %    \begin{macrocode}
   \begin{beamercolorbox}[sep=0pt,#1]{empty}
     \vskip8pt
-    \raggedright%
     \hfuzz=130pt%
     \usebeamercolor[fg]{palette primary}%
     \if\EqualOption{inner}{lang}{en}%

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/05/18 v2.9.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/07/19 v2.9.1 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -217,7 +217,7 @@
 %   WARNING: The pattern in the title page is now deprecated for the unstability of the \verb"fadings" library in TikZ. If you want to use the pattern, please uncomment the code segement manually. The interface of \verb"stamparry" is functional.
 %   If it is in draftmode or it is not compatible, no pattern will get rendered.
 %   Otherwise, the fade tile of stamp array will get covered on top of the background rectangle.
-%   \verb"stamparray" is defined in \verb"SJTUvi". Then, a fade right covers this array layer and a center fade covers the previous result.
+%   \verb"stamparray" is defined in \verb"sjtuvi". Then, a fade right covers this array layer and a center fade covers the previous result.
 %    \begin{macrocode}
   \ifx\sjtubeamer@compatible\sjtubeamer@compatible@false
   \else
@@ -249,39 +249,11 @@
   \begin{beamercolorbox}{empty}
     \usebeamercolor[fg]{palette primary}
     \vskip8pt
-    \hbox{
-      \hskip-4pt{\resizebox{!}{1cm}{\vphantom{-}\usebeamertemplate{logo}}}
-      \ifx\insertinstitute\@empty%
-      \else
-      \ifx\insertlogo\@empty%
-        \else
-        {\hskip0pt\vrule width0.5pt}\hskip0pt
-      \fi
-      \if\EqualOption{inner}{lang}{en}
-      \vbox to 1cm{
-          \vfill
-          \vbox{
-            \offinterlineskip
-            \noindent \strut
-            \baselineskip 0pt \lineskip -2pt
-            \scriptsize\textsc{\beamer@shortinstitute}
-            \strut
-          }
-          \vfill
-        }
-      \else
-      \hskip3pt\vbox{
-        \fontsize{13pt}{0pt}\selectfont
-        \insertinstitute
-        \par\noindent\vskip0.14em
-        \fontsize{5pt}{0pt}\selectfont
-        \textsc{\insertshortinstitute}
-        \baselineskip 3.9pt
-        \par~
-      }
-      \fi
-      \fi%
-    }
+    \if\EqualOption{inner}{lang}{en}
+      \secondaryinstlogo{\beamer@shortinstitute}{\usebeamertemplate{logo}}
+    \else
+      \secondaryinstlogo[\insertshortinstitute]{\insertinstitute}{\usebeamertemplate{logo}}
+    \fi
     \vskip8pt
   \end{beamercolorbox}
 %    \end{macrocode}
@@ -448,7 +420,7 @@
 \defbeamertemplate*{bottom page}{min}[1][]
 {
 %    \end{macrocode}
-%   Enter vertical mode.
+%   Leave vertical mode, which is equivalent to \verb"\leavevmode".
 %    \begin{macrocode}
   \vbox{}
 %    \end{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -135,19 +135,20 @@
       \node {\includegraphics[height=1.5cm]{#1/#2}};
     \end{tikzfadingfrompicture}
   \fi
-  \expandafter\providecommand\csname #2\endcsname[1][]{
+  \expandafter\providecommand\csname #2\endcsname[1][]{%
     % ##1: override color, or opacity=... (optional)
-    \tikzexternaldisable
-    \begin{tikzpicture}
+    \tikzexternaldisable%
+    \begin{tikzpicture}%
       \begin{scope}
         \clip ({-1.0+#3},{-1.0+#4}) rectangle ({1.0-#3},{1.0-#4});
-        \fill [##1, path fading=#2]
-          (-1,-1) rectangle (1,1);
+        \fill [##1, path fading=#2] (-1,-1) rectangle (1,1);
       \end{scope}
-    \end{tikzpicture}
+    \end{tikzpicture}%
   }
 }
 %    \end{macrocode}
+% WARNING: when using \verb"\resizebox" or in some boxes, the end of the line will be treated as a space according to the \LaTeX{} rule, which may cause extra space when measuring the object.
+% Use \verb"%" symbol at the end of the line to avoid the unwanted space, which is recommended to all lines in the command or the start and the end of the outer environment.
 % \end{macro}
 %
 %    Define the required logo.
@@ -163,48 +164,51 @@
 %
 %  \begin{macro}{\secondaryinstlogo}
 %  Logo with secondary institute.
-%  TODO: remove hard-coded -4pt left adjustment.
+%  The first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name.
+%  The second mandantory parameter is the main name for your institute.
+%  The third parameter is the logo of the left side, you could leave it as empty but mandantory.
 %    \begin{macrocode}
-\newcommand{\secondaryinstlogo}[3][]{
+\newcommand{\secondaryinstlogo}[3][]{%
   % #1: shortinst (optional)
   % #2: longinst
   % #3: logo
-  {
-    \def\shortinst{#1}
-    \def\longinst{#2}
-    \def\mylogo{#3}
-    \hbox{
-      \hskip-4pt\resizebox{!}{1cm}{\vphantom{-}#3}
-      \ifx\longinst\@empty%
+  \def\shortinst{#1}%
+  \def\longinst{#2}%
+  \def\mylogo{#3}%
+  \hbox to \textwidth{%
+    \resizebox{!}{1cm}{\vphantom{-}#3}%
+    \ifx\longinst\@empty%
+    \else%
+      \ifx\shortinst\@empty%
+        \ifx\mylogo\@empty\else%
+          \hskip0.31cm{\vrule width0.5pt}\hskip0.31cm%
+        \fi%
+        \vbox to 1cm{
+          \vfill
+          \vbox{
+            \offinterlineskip
+            \noindent \strut
+            \baselineskip 0pt \lineskip -2pt
+            \hbox{\scriptsize\textsc{#2}}
+            \strut
+          }
+          \vfill
+        }
       \else%
         \ifx\mylogo\@empty\else%
-          {\hskip0pt\vrule width0.5pt}\hskip10pt
+          \hskip0.23cm{\vrule width0.5pt}\hskip0.23cm%
         \fi%
-        \ifx\shortinst\@empty%
-          \vbox to 1cm{
-            \vfill
-            \vbox{
-              \offinterlineskip
-              \noindent \strut
-              \baselineskip 0pt \lineskip -2pt
-              \scriptsize\textsc{#2}
-              \strut
-            }
-            \vfill
-          }
-        \else%
-          \vbox{
-            \fontsize{13pt}{0pt}\selectfont
-            #2
-            \par\noindent\vskip0.14em
-            \fontsize{5pt}{0pt}\selectfont
-            \textsc{#1}
-            \baselineskip 3.9pt
-            \par~
-          }
-        \fi
+        \vbox{
+          \fontsize{13pt}{0pt}\selectfont
+          #2
+          \par\noindent\vskip0.14em
+          \fontsize{5pt}{0pt}\selectfont
+          \textsc{#1}
+          \baselineskip 3.9pt
+          \par~
+        }
       \fi
-    }
+    \fi
   }
 }
 %    \end{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -147,8 +147,9 @@
   }
 }
 %    \end{macrocode}
-% WARNING: when using \verb"\resizebox" or in some boxes, the end of the line will be treated as a space according to the \LaTeX{} rule, which may cause extra space when measuring the object.
+% WARNING: When using \verb"\resizebox" or in some boxes, the end of the line will be treated as a space according to the \LaTeX{} rule, which may cause extra space when measuring the object.
 % Use \verb"%" symbol at the end of the line to avoid the unwanted space, which is recommended to all lines in the command or the start and the end of the outer environment.
+% TODO: add the feature to insert a logo with or without the safe spacing (1/5h).
 % \end{macro}
 %
 %    Define the required logo.
@@ -165,50 +166,76 @@
 %  \begin{macro}{\secondaryinstlogo}
 %  Logo with secondary institute.
 %  The first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name.
+%  The macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \verb"\\".
 %  The second mandantory parameter is the main name for your institute.
 %  The third parameter is the logo of the left side, you could leave it as empty but mandantory.
 %    \begin{macrocode}
-\newcommand{\secondaryinstlogo}[3][]{%
+\newcommand*{\secondaryinstlogo}[3][]{%
   % #1: shortinst (optional)
   % #2: longinst
   % #3: logo
   \def\shortinst{#1}%
   \def\longinst{#2}%
   \def\mylogo{#3}%
-  \hbox to \textwidth{%
+%    \end{macrocode}
+%   Start a hbox as a container. 
+%   Remember the end of the line will be treated as a space in the paramter of \verb"hbox" (which is a \TeX{} primitive). To avoid that, add a \verb"%" at the end of the line.
+%    \begin{macrocode}
+  \hbox{%
+%    \end{macrocode}
+%   Insert the resized logo. The empty logo is supported as we insert \verb"\vphantom" here.
+%    \begin{macrocode}
     \resizebox{!}{1cm}{\vphantom{-}#3}%
     \ifx\longinst\@empty%
+%    \end{macrocode}
+%   If the long institute name is empty the right part will not be typesetted.
+%    \begin{macrocode}
     \else%
       \ifx\shortinst\@empty%
+%    \end{macrocode}
+%   If the short institute is empty, the English version of the combined logo will be configured.
+%   The margin around the vrule is 0.31cm in this manner.
+%    \begin{macrocode}
         \ifx\mylogo\@empty\else%
-          \hskip0.31cm{\vrule width0.5pt}\hskip0.31cm%
+          {\hskip0.31cm\vrule width0.5pt}\hskip0.31cm%
         \fi%
-        \vbox to 1cm{
-          \vfill
-          \vbox{
-            \offinterlineskip
-            \noindent \strut
-            \baselineskip 0pt \lineskip -2pt
-            \hbox{\scriptsize\textsc{#2}}
-            \strut
-          }
-          \vfill
-        }
+%    \end{macrocode}
+%   You need to manually break the line for the main English name. The whole name will be typesetted centered vertically.
+%    \begin{macrocode}
+        \vbox to 1cm{%
+          \vfill%
+%    \end{macrocode}
+%   Here, \verb"\baselineskip" is set to 0pt, which will always violate the rule that border distance between two lines should be greater than \verb"\lineskiplimit".
+%   And the \verb"\lineskip" will be applied to enlarge the distance. In this manner, the adjustment will be font-size free.
+%    \begin{macrocode}
+          \baselineskip 0pt\lineskip 2pt%
+          \noindent%
+          \fontsize{7.5pt}{0pt}\selectfont\scshape #2%
+          \vfill%
+        }%
       \else%
+%    \end{macrocode}
+%   If the short institute name is not empty, the short name will be typesetted below the long name.
+%   The margin around the vrule is 0.23cm in this manner.
+%    \begin{macrocode}
         \ifx\mylogo\@empty\else%
-          \hskip0.23cm{\vrule width0.5pt}\hskip0.23cm%
+          {\hskip0.23cm\vrule width0.5pt}\hskip0.23cm%
         \fi%
-        \vbox{
-          \fontsize{13pt}{0pt}\selectfont
-          #2
-          \par\noindent\vskip0.14em
+        \vbox to 1cm{%
+%    \end{macrocode}
+%   Close the interlineskip to use hard-coded value between lines.
+%    \begin{macrocode}
+          \offinterlineskip
+          \vfill
+          \fontsize{13pt}{0pt}\selectfont #2
+          \vskip0.08cm
           \fontsize{5pt}{0pt}\selectfont
           \textsc{#1}
-          \baselineskip 3.9pt
-          \par~
-        }
+          \vskip0.14cm
+        }%
       \fi
     \fi
+    \hss%
   }
 }
 %    \end{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/05/18 v2.9.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/07/19 v2.9.1 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -161,6 +161,54 @@
 \definelogo{sjtugate}{0.25}{0.8}
 %    \end{macrocode}
 %
+%  \begin{macro}{\secondaryinstlogo}
+%  Logo with secondary institute.
+%  TODO: remove hard-coded -4pt left adjustment.
+%    \begin{macrocode}
+\newcommand{\secondaryinstlogo}[3][]{
+  % #1: shortinst (optional)
+  % #2: longinst
+  % #3: logo
+  {
+    \def\shortinst{#1}
+    \def\longinst{#2}
+    \def\mylogo{#3}
+    \hbox{
+      \hskip-4pt\resizebox{!}{1cm}{\vphantom{-}#3}
+      \ifx\longinst\@empty%
+      \else%
+        \ifx\mylogo\@empty\else%
+          {\hskip0pt\vrule width0.5pt}\hskip10pt
+        \fi%
+        \ifx\shortinst\@empty%
+          \vbox to 1cm{
+            \vfill
+            \vbox{
+              \offinterlineskip
+              \noindent \strut
+              \baselineskip 0pt \lineskip -2pt
+              \scriptsize\textsc{#2}
+              \strut
+            }
+            \vfill
+          }
+        \else%
+          \vbox{
+            \fontsize{13pt}{0pt}\selectfont
+            #2
+            \par\noindent\vskip0.14em
+            \fontsize{5pt}{0pt}\selectfont
+            \textsc{#1}
+            \baselineskip 3.9pt
+            \par~
+          }
+        \fi
+      \fi
+    }
+  }
+}
+%    \end{macrocode}
+%  \end{macro}
 %
 % \subsubsection{Shape Declarations}
 %
@@ -306,9 +354,9 @@
 % \end{macro}
 %
 % \begin{macro}{stampline}
-%	  Declare a decoration to make a loop stampline.
+%   Declare a decoration to make a loop stampline.
 %
-%	  Notice that \verb"auto corner on length" is open to avoid spikes where the state hasn't meet \verb"final" yet.
+%   Notice that \verb"auto corner on length" is open to avoid spikes where the state hasn't meet \verb"final" yet.
 %    \begin{macrocode}
 \pgfdeclaredecoration{stampline}{initial}
 {

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -221,21 +221,17 @@
         \ifx\mylogo\@empty\else%
           {\hskip0.23cm\vrule width0.5pt}\hskip0.23cm%
         \fi%
-        \vbox to 1cm{%
-%    \end{macrocode}
-%   Close the interlineskip to use hard-coded value between lines.
-%    \begin{macrocode}
-          \offinterlineskip
-          \vfill
-          \fontsize{13pt}{0pt}\selectfont #2
-          \vskip0.08cm
+        \vbox{%
+          \fontsize{13pt}{0pt}\selectfont
+          #2
+          \par\noindent\vskip0.14em
           \fontsize{5pt}{0pt}\selectfont
           \textsc{#1}
-          \vskip0.14cm
+          \baselineskip 3.9pt
+          \par~
         }%
       \fi
     \fi
-    \hss%
   }
 }
 %    \end{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -169,6 +169,7 @@
 %  The macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \verb"\\".
 %  The second mandantory parameter is the main name for your institute.
 %  The third parameter is the logo of the left side, you could leave it as empty but mandantory.
+%  By default, this combination will occupy the whole row.
 %    \begin{macrocode}
 \newcommand*{\secondaryinstlogo}[3][]{%
   % #1: shortinst (optional)
@@ -182,6 +183,10 @@
 %   Remember the end of the line will be treated as a space in the paramter of \verb"hbox" (which is a \TeX{} primitive). To avoid that, add a \verb"%" at the end of the line.
 %    \begin{macrocode}
   \hbox{%
+%    \end{macrocode}
+%   Make sure the content is left aligned.
+%    \begin{macrocode}
+    \raggedright%
 %    \end{macrocode}
 %   Insert the resized logo. The empty logo is supported as we insert \verb"\vphantom" here.
 %    \begin{macrocode}
@@ -223,10 +228,13 @@
         \fi%
         \vbox{%
           \fontsize{13pt}{0pt}\selectfont
-          #2
+          \sffamily #2
           \par\noindent\vskip0.14em
           \fontsize{5pt}{0pt}\selectfont
-          \textsc{#1}
+          \scshape #1
+%    \end{macrocode}
+%   \verb"\baselineskip" will be applied to the next empty line, to make sure the bottom padding is relative to the baseline.
+%    \begin{macrocode}
           \baselineskip 3.9pt
           \par~
         }%

--- a/src/testfiles/sjtuvi.lvt
+++ b/src/testfiles/sjtuvi.lvt
@@ -4,6 +4,8 @@
 \def\colorblock#1{
     #1\hfill\tikz{\draw[black,fill=#1] (-1,-0.25) rectangle (1,0.25);}\par
 }
+\usepackage{silence}
+\WarningFilter{latexfont}{Font shape}  % KNOWN WARNING
 \begin{document}
     \START
     \begin{frame}
@@ -42,6 +44,12 @@
               path has corners=true,
             },decorate,sjtuRedPrimary] (-2,-2) rectangle (2,2);
         \end{tikzpicture}
+        \stamptext{Test}
+    \end{frame}
+    \begin{frame}
+        \frametitle{Secondary Institute Logo}
+        \secondaryinstlogo{Institute}{\phantom{-}}
+        \secondaryinstlogo[Institute]{INSTITUTE}{\phantom{-}}
     \end{frame}
     \END
 \end{document}

--- a/src/testfiles/sjtuvi.tlg
+++ b/src/testfiles/sjtuvi.tlg
@@ -2,5 +2,7 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 [1
 ]
+\s=\skip...
 [3
+] [4
 ]


### PR DESCRIPTION
将二级机构徽标抽象为宏 `\secondaryinstlogo`，便于后续调用。

```latex
\secondaryinstlogo[英文名]{中文名}{徽标}
\secondaryinstlogo{英文名}{徽标}
```

**重要修正**：清除 `\resizebox` 缩放 `\definelogo` 产生徽标产生的两侧多余空格。 a4c238e09e4825a5031be93a81fbb76abe1fa70c