### PR TITLE
feat: \secondaryinstlogo

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -86,7 +86,7 @@
 	"codeblockinput": {
 		"scope": "doctex,tex,latex",
 		"prefix": "\\codeblockinput",
-		"body": "\\codeblockinput[${1:}]{$2}{$3}{$4}",
+		"body": "\\codeblockinput[${1:}]{$2}{$3}",
 		"description": "Code block environment for external file input. The same style like codeblock.\nThe first optional parameter is passed to listing.\nThe second required parameter receives the title to make.\nThe third required paramter receives the file to typeset.\nADVANCED TIP: For longer typeset, use lstinputlisting command directly and remove the frame environment around the code input for occupying cross the pages. No numbering is preset so you need to set the number manually for this basic command.\n"
 	},
 	"sjtubeamer@outer@nav": {

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -231,7 +231,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\\secondaryinstlogo",
 		"body": "\\secondaryinstlogo[${1:}]{$2}{$3}",
-		"description": "Logo with secondary institute.\nThe first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name.\nThe macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \\\\ but NOT \\par.\nThe second mandantory parameter is the main name for your institute.\nThe third parameter is the logo of the left side, you could leave it as empty but mandantory.\nBy default, this combination will occupy the whole row.\n"
+		"description": "Logo with secondary institute.\nThe first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name. SHOULD BE NO \\\\.\nThe second mandantory parameter is the main name for your institute. when the optional paramter is empty, you COULD USE \\\\ as linebreaks. BUT NOT \\par.\nThe third parameter is the logo of the left side, you could leave it as empty but mandantory.\nBy default, this combination will occupy the whole row.\n"
 	},
 	"stamptext": {
 		"scope": "doctex,tex,latex",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -231,7 +231,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\\secondaryinstlogo",
 		"body": "\\secondaryinstlogo[${1:}]{$2}{$3}",
-		"description": "Logo with secondary institute.\nThe first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name. SHOULD BE NO \\\\.\nThe second mandantory parameter is the main name for your institute. when the optional paramter is empty, you COULD USE \\\\ as linebreaks. BUT NOT \\par.\nThe third parameter is the logo of the left side, you could leave it as empty but mandantory.\nBy default, this combination will occupy the whole row.\n"
+		"description": "Logo with secondary institute.\nThe first optional parameter is typically the English name for your institute. If it exists (Chinese style), will be typesetted below the main name. THERE SHOULD BE NO \\\\.\nThe second mandantory parameter is the main name for your institute. when the optional paramter is empty (English style), YOU COULD USE \\\\ as linebreaks. BUT NO \\par is allowed.\nThe third parameter is the logo on the left side, you could leave it as empty but it is mandantory.\nWhen it is in English style (no optional parameter), you could use a secondary logo picture as your institute, but remember to resize the height to 0.95cm.\n"
 	},
 	"stamptext": {
 		"scope": "doctex,tex,latex",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -231,7 +231,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\\secondaryinstlogo",
 		"body": "\\secondaryinstlogo[${1:}]{$2}{$3}",
-		"description": "Logo with secondary institute.\nThe first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name.\nThe macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \\\\.\nThe second mandantory parameter is the main name for your institute.\nThe third parameter is the logo of the left side, you could leave it as empty but mandantory.\nBy default, this combination will occupy the whole row.\n"
+		"description": "Logo with secondary institute.\nThe first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name.\nThe macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \\\\ but NOT \\par.\nThe second mandantory parameter is the main name for your institute.\nThe third parameter is the logo of the left side, you could leave it as empty but mandantory.\nBy default, this combination will occupy the whole row.\n"
 	},
 	"stamptext": {
 		"scope": "doctex,tex,latex",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}
@@ -266,7 +266,6 @@
     }
   }{}
   \@ifpackageloaded{pgfplotstable}{%
-    \RequirePackage{array}
     \RequirePackage{colortbl}
     \RequirePackage{booktabs}
     \def\zapcolorreset{\let\reset@color\relax\ignorespaces}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/07/19 v2.9.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/07/28 v2.9.2 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}
@@ -152,7 +152,6 @@
   \begingroup
   \centering
   \begin{beamercolorbox}[sep=8pt,#1]{empty}
-    \hfuzz=130pt%
     \usebeamercolor[fg]{palette primary}%
     \if\EqualOption{cover}{lang}{en}%
       \secondaryinstlogo{\beamer@shortinstitute}{\usebeamertemplate{logo}}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -153,6 +153,7 @@
   \centering
   \begin{beamercolorbox}[sep=8pt,#1]{empty}
     \usebeamercolor[fg]{palette primary}%
+    \hspace*{-0.6pt}%
     \if\EqualOption{cover}{lang}{en}%
       \secondaryinstlogo{\beamer@shortinstitute}{\usebeamertemplate{logo}}
     \else%

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/07/19 v2.9.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/07/28 v2.9.2 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{%
   % #1: package
   % #2: key
@@ -49,6 +49,7 @@
 \definecolor{sjtuBluePrimary}{RGB}{0,64,152}         %problue
 \definecolor{sjtuBlueSecondary}{RGB}{51,141,39}      %lightgreen
 \definecolor{sjtuBlueTertiary}{RGB}{0,81,78}         %lightgray
+\RequirePackage{array}
 \newcommand{\definelogo}[4][vi]{
   % #1: folder
   % #2: file from #1 folder
@@ -104,7 +105,7 @@
           \vfill%
           \hbox{%
             \noindent%
-            \fontsize{7.5pt}{0pt}\selectfont\mdseries\scshape%
+            \fontsize{7pt}{0pt}\selectfont\mdseries\scshape%
             \begin{tabular}{@{}l<{\vphantom{\vrule depth2pt}}@{}}
               #2
             \end{tabular}%
@@ -116,14 +117,19 @@
         \ifx\mylogo\@empty\else%
           {\hskip0.23cm\vrule width0.5pt}\hskip0.23cm%
         \fi%
-        \vbox{%
-          \fontsize{13pt}{0pt}\selectfont
-          \mdseries\sffamily #2
-          \par\noindent\vskip0.14em
-          \fontsize{5pt}{0pt}\selectfont
-          \scshape #1
-          \baselineskip 3.9pt
-          \par~
+        \vbox to 1cm{%
+          \vfill
+          \offinterlineskip
+          \hbox{%
+            \fontsize{13pt}{0pt}\selectfont%
+            \mdseries\sffamily #2%
+          }
+          \vskip0.08cm%
+          \hbox{%
+            \fontsize{5pt}{0pt}\selectfont%
+            \mdseries\scshape #1%
+          }
+          \vskip-\prevdepth\vskip0.14cm%
         }%
       \fi
     \fi

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -102,9 +102,14 @@
         \fi%
         \vbox to 1cm{%
           \vfill%
-          \baselineskip 0pt\lineskip 2pt%
-          \noindent%
-          \fontsize{7.5pt}{0pt}\selectfont\mdseries\scshape #2%
+          \hbox{%
+            \noindent%
+            \fontsize{7.5pt}{0pt}\selectfont\mdseries\scshape%
+            \begin{tabular}{@{}l<{\vphantom{\vrule depth2pt}}@{}}
+              #2
+            \end{tabular}%
+          }%
+          \vskip-2pt%
           \vfill%
         }%
       \else%

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -104,7 +104,7 @@
           \vfill%
           \baselineskip 0pt\lineskip 2pt%
           \noindent%
-          \fontsize{7.5pt}{0pt}\selectfont\scshape #2%
+          \fontsize{7.5pt}{0pt}\selectfont\mdseries\scshape #2%
           \vfill%
         }%
       \else%
@@ -113,7 +113,7 @@
         \fi%
         \vbox{%
           \fontsize{13pt}{0pt}\selectfont
-          \sffamily #2
+          \mdseries\sffamily #2
           \par\noindent\vskip0.14em
           \fontsize{5pt}{0pt}\selectfont
           \scshape #1

--- a/src/build.lua
+++ b/src/build.lua
@@ -228,7 +228,9 @@ function gen_snippets()
                     end
                     if captured == 3 then   -- close the environment
                         macro_body = macro_body .. "\\n\\t$" .. comm_param + 1 .. "\\n\\\\end{" .. in_macro .. "}\\n"
-                    elseif string.find(comm_decl, "command") == nil then -- it is a definition method from 3rd party package, which often requires an applying region.
+                    elseif string.find(comm_decl, "command") == nil and string.find(comm_decl, "input") == nil then
+                        -- it is a definition method from 3rd party package, which often requires an applying region.
+                        -- except for \newtcbinputlisting
                         macro_body = macro_body .. "{$" .. comm_param + 1 .. "}"
                     end
                 -- Find begin macrocode environment, see Coding Style 3.3.2

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -560,7 +560,7 @@ fontupper=\sffamily,colupper=white}
 \begin{tcbitemize}[raster rows=3, raster columns=1, raster every box/.style={center title, valign=center, halign=center,fonttitle=\ttfamily,colback=white}]
   \tcbitem[title={\cmd{secondaryinstlogo[$\langle\textit{en}\rangle$]\{$\langle\textit{zh}\rangle$\}\{$\langle\textit{logo}\rangle$\}}}] \resizebox{!}{1cm}{\secondaryinstlogo[School of Electronic, Information and Electrical Engineering]{电子信息与电气工程学院}{\zhlogo{}}}
   \tcbitem[title={\cmd{secondaryinstlogo\{$\langle\textit{en}\rangle$\}\{$\langle\textit{logo}\rangle$\}}}] \resizebox{!}{1cm}{\secondaryinstlogo{School of Electronic, \\ Information and Electrical Engineering}{\enlogo{}}}
-  \tcbitem[title={\cmd{secondaryinstlogo\{\cmd{resizebox}\{!\}\{0.95cm\}\{$\langle\textit{logo2}\rangle$\}\}\{$\langle\textit{logo}\rangle$\}}}] \resizebox{!}{1cm}{\secondaryinstlogo{\resizebox{!}{0.95cm}{\includegraphics{sjtug.pdf}}}{\sjtubadge[sjtuRedPrimary]{}}} 
+  \tcbitem[title={\cmd{secondaryinstlogo\{\cmd{resizebox}\{!\}\{0.95cm\}\{$\langle\textit{logo2}\rangle$\}\}\{$\langle\textit{logo}\rangle$\}}}] \resizebox{!}{1cm}{\secondaryinstlogo{\resizebox{!}{0.95cm}{\includegraphics{sjtug.pdf}}}{\sjtubadge{}}} 
 \end{tcbitemize}
 
 \begin{commentlist}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -634,9 +634,9 @@ fontupper=\sffamily,colupper=white}
 
 \begin{table}[h]
   \centering
-  \begin{tabular}{>{\sffamily}c>{\sffamily}c}
+  \begin{tabular}{>{\sffamily}c>{\sffamily}c>{\sffamily}c}
     \hline
-    tikz & tcolorbox \\
+    tikz & tcolorbox & array\\
     \hline
   \end{tabular}
 \end{table}

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -529,15 +529,15 @@ fontupper=\sffamily,colupper=white}
 
 \themename{} 内置了一些徽标可供更换$^*$。
 
-\faInfoCircle{} 徽标与相关元素版权归上海交通大学所有，仅供学习交流使用。
+\section{校徽}
 
 \begin{tcbitemize}[raster rows=2, raster columns=3, raster every box/.style={center title, valign=center, halign=center,fonttitle=\ttfamily,colback=white}]
   \tcbitem[raster multicolumn=2,blankest]
   \begin{tcbitemize}[raster columns=2]
     \tcbitem[title={\cmd{zhlogo}}]
-    \moveleft 0.3cm\hbox{\resizebox{!}{1cm}{\zhlogo}}
+    \hbox{\resizebox{!}{1cm}{\zhlogo}}
     \tcbitem[title={\cmd{enlogo}}]
-    \moveleft 0.3cm\hbox{\resizebox{!}{1cm}{\enlogo}}
+    \hbox{\resizebox{!}{1cm}{\enlogo}}
     \tcbitem[title={\cmd{sjtubadge}},height=3.5cm]
     \resizebox{!}{2cm}{\sjtubadge{}}
     \tcbitem[title={\cmd{dlogo}},height=3.5cm]
@@ -552,6 +552,23 @@ fontupper=\sffamily,colupper=white}
   \item 使用 \cmd{logo} 设定徽标。在主题处使用 \opt{topright} 或 \opt{bottomright} 选项强制指定徽标的位置为右上角（\opt{max} 默认）或左下角（\opt{maxplus} 和 \opt{min}）。
   \item 可以使用自定义的徽标，可以使用外部图片，或参见\href{run:sjtubeamerdevguide.pdf}{开发指南}第 3.4 节创造可变颜色徽标$^*$。后者可以采用可选参数改变颜色，比如 \cmd{zhlogo[cprimary]}。
 \end{commentlist}
+
+\section{二级机构组合}
+
+也可以使用中文样式、英文样式与图片样式的二级机构组合。
+
+\begin{tcbitemize}[raster rows=3, raster columns=1, raster every box/.style={center title, valign=center, halign=center,fonttitle=\ttfamily,colback=white}]
+  \tcbitem[title={\cmd{secondaryinstlogo[$\langle\textit{en}\rangle$]\{$\langle\textit{zh}\rangle$\}\{$\langle\textit{logo}\rangle$\}}}] \resizebox{!}{1cm}{\secondaryinstlogo[School of Electronic, Information and Electrical Engineering]{电子信息与电气工程学院}{\zhlogo{}}}
+  \tcbitem[title={\cmd{secondaryinstlogo\{$\langle\textit{en}\rangle$\}\{$\langle\textit{logo}\rangle$\}}}] \resizebox{!}{1cm}{\secondaryinstlogo{School of Electronic, \\ Information and Electrical Engineering}{\enlogo{}}}
+  \tcbitem[title={\cmd{secondaryinstlogo\{\cmd{resizebox}\{!\}\{0.95cm\}\{$\langle\textit{logo2}\rangle$\}\}\{$\langle\textit{logo}\rangle$\}}}] \resizebox{!}{1cm}{\secondaryinstlogo{\resizebox{!}{0.95cm}{\includegraphics{sjtug.pdf}}}{\sjtubadge[sjtuRedPrimary]{}}} 
+\end{tcbitemize}
+
+\begin{commentlist}
+  \item 只有在不含可选参数的情况下（英文样式），可以在主要机构名中使用 \textbackslash\textbackslash{} 对机构名进行换行。
+  \item 注意与 \cmd{institute} 设置上的区别，非必要情况下最好直接使用 \cmd{institute} 生成二级机构组合（比如 \opt{min} 样式的封面页）。
+\end{commentlist}
+
+\faInfoCircle{} 徽标与相关元素版权归上海交通大学所有，仅供学习交流使用。
 
 \chapter{头图}
 

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -567,7 +567,6 @@
 %   Set the style of \textsc{Pgfplotstable}. The \verb"\colorrows" macro here is used for making the header colored. The \verb"booktabs" line is used to create a professional look.
 %    \begin{macrocode}
   \@ifpackageloaded{pgfplotstable}{%
-    \RequirePackage{array}
     \RequirePackage{colortbl}
     \RequirePackage{booktabs}
 %    \end{macrocode}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/07/19 v2.9.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/07/28 v2.9.2 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -245,9 +245,11 @@
 %   \verb"resizebox" is used to adapt to all size of logo into 1cm height one. And it is the same in outer theme to make a 0.7cm logo. 
 %   The institute is in \TeX{} code for typesetting. \verb"\beamer@shortinstitute" meta is used to avoid compressing on \verb"\par", while \verb"\insertinstitute" will force the input to spread on one signle line. The mode to use is depended on the \verb"language" option. Super small font could be made by \verb"fontsize".
 %   NOTE: When you use the picture as the secondary institute, make sure it is the parameter that will be displayed. For \verb"zh" option, the optional parameter should leaved as empty explicitly, i.e., \verb"\institute[]{<pic>}", otherwise the shortinstitute will be the same as the main parameter. For \verb"en" option, the optional parameter should be the picture, i.e., \verb"\institute[<pic>]{}". The picture should be 0.95cm in height, as noted in \verb"\secondaryinstlogo" in \verb"sjtuvi".
+%   FIXME: since the logo has some tiny margin, the left alignment seems not so perfect. Hence a -0.6pt visual compensation is added to address the issue. This will be fixed in the future through a better clip and safe margin control on \verb"\definelogo".
 %    \begin{macrocode}
   \begin{beamercolorbox}[sep=8pt,#1]{empty}
     \usebeamercolor[fg]{palette primary}%
+    \hspace*{-0.6pt}%
     \if\EqualOption{cover}{lang}{en}%
       \secondaryinstlogo{\beamer@shortinstitute}{\usebeamertemplate{logo}}
     \else%

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/07/19 v2.9.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/07/28 v2.9.2 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}
@@ -245,10 +245,8 @@
 %   \verb"resizebox" is used to adapt to all size of logo into 1cm height one. And it is the same in outer theme to make a 0.7cm logo. 
 %   The institute is in \TeX{} code for typesetting. \verb"\beamer@shortinstitute" meta is used to avoid compressing on \verb"\par", while \verb"\insertinstitute" will force the input to spread on one signle line. The mode to use is depended on the \verb"language" option. Super small font could be made by \verb"fontsize".
 %   Here, we use the option from inner to get the language setting, if this package is used independently, only chinese mode is available.
-%   Set \verb"\hfuzz" to 130pt to avoid the overfull hbox warning.
 %    \begin{macrocode}
   \begin{beamercolorbox}[sep=8pt,#1]{empty}
-    \hfuzz=130pt%
     \usebeamercolor[fg]{palette primary}%
     \if\EqualOption{cover}{lang}{en}%
       \secondaryinstlogo{\beamer@shortinstitute}{\usebeamertemplate{logo}}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -244,7 +244,7 @@
 %    \end{macrocode}
 %   \verb"resizebox" is used to adapt to all size of logo into 1cm height one. And it is the same in outer theme to make a 0.7cm logo. 
 %   The institute is in \TeX{} code for typesetting. \verb"\beamer@shortinstitute" meta is used to avoid compressing on \verb"\par", while \verb"\insertinstitute" will force the input to spread on one signle line. The mode to use is depended on the \verb"language" option. Super small font could be made by \verb"fontsize".
-%   Here, we use the option from inner to get the language setting, if this package is used independently, only chinese mode is available.
+%   NOTE: When you use the picture as the secondary institute, make sure it is the parameter that will be displayed. For \verb"zh" option, the optional parameter should leaved as empty explicitly, i.e., \verb"\institute[]{<pic>}", otherwise the shortinstitute will be the same as the main parameter. For \verb"en" option, the optional parameter should be the picture, i.e., \verb"\institute[<pic>]{}". The picture should be 0.95cm in height, as noted in \verb"\secondaryinstlogo" in \verb"sjtuvi".
 %    \begin{macrocode}
   \begin{beamercolorbox}[sep=8pt,#1]{empty}
     \usebeamercolor[fg]{palette primary}%

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -256,7 +256,7 @@
           \vskip0.08cm%
           \hbox{%
             \fontsize{5pt}{0pt}\selectfont%
-            \scshape #1%
+            \mdseries\scshape #1%
           }
 %    \end{macrocode}
 %   \verb"\prevdepth" is used to reduce the bottom padding by the depth of the previous line in case that the line has a comma.

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -226,10 +226,13 @@
             \fontsize{7.5pt}{0pt}\selectfont\mdseries\scshape%
 %    \end{macrocode}
 %   Since the parameter could contain the breaklines \verb"\\", which is not function in the horizontal mode. To make the thing work, wrap it into the \verb"tabular" environment, and remove the left-right padding by \verb"@{}". Then the paramter could break lines.
-%   FIXME: Now it uses a phantom comma to emulate the a certain depth to increase the line height.
+%   To increase the interlineskip in tabular, use a phantom vrule at the end of each line with the depth of 2pt. At the end of the tabular, we should decrease the vskip by 2pt since the last line should not have that depth to make sure the content is vertically centered.
 %    \begin{macrocode}
-            \begin{tabular}{@{}l<{\vphantom{,}}@{}}#2\end{tabular}%
+            \begin{tabular}{@{}l<{\vphantom{\vrule depth2pt}}@{}}
+              #2
+            \end{tabular}%
           }%
+          \vksip-2pt%
 %    \end{macrocode}
 %   In this way, the behavior like textbox in MS Word could be achieved, with the combination of \verb"\hbox" and \verb"tabular" environment, to make sure the bounding box could be measured and the content could use normal \verb"\\" for breaking lines. But \verb"\par" is not acceptable so you should use the hard-breaking in the command parameter.
 %    \begin{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -208,7 +208,7 @@
 %    \end{macrocode}
 %   You need to manually break the line for the main English name. The whole name will be typesetted centered vertically.
 %    \begin{macrocode}
-        \vbox to 1cm{%
+        \vbox to 1cm{\hsize 7cm%
           \vfill%
 %    \end{macrocode}
 %   Here, \verb"\baselineskip" is set to 0pt, which will always violate the rule that border distance between two lines should be greater than \verb"\lineskiplimit".
@@ -228,17 +228,19 @@
         \ifx\mylogo\@empty\else%
           {\hskip0.23cm\vrule width0.5pt}\hskip0.23cm%
         \fi%
-        \vbox{%
-          \fontsize{13pt}{0pt}\selectfont
-          \mdseries\sffamily #2
-          \par\noindent\vskip0.14em
-          \fontsize{5pt}{0pt}\selectfont
-          \scshape #1
-%    \end{macrocode}
-%   \verb"\baselineskip" will be applied to the next empty line, to make sure the bottom padding is relative to the baseline.
-%    \begin{macrocode}
-          \baselineskip 3.9pt
-          \par~
+        \vbox to 1cm{%
+          \vfill
+          \offinterlineskip
+          \hbox{%
+            \fontsize{13pt}{0pt}\selectfont%
+            \mdseries\sffamily #2%
+          }
+          \vskip0.08cm%
+          \hbox{%
+            \fontsize{5pt}{0pt}\selectfont%
+            \scshape #1%
+          }
+          \vskip-\prevdepth\vskip0.14cm%
         }%
       \fi
     \fi

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -232,7 +232,7 @@
               #2
             \end{tabular}%
           }%
-          \vksip-2pt%
+          \vskip-2pt%
 %    \end{macrocode}
 %   In this way, the behavior like textbox in MS Word could be achieved, with the combination of \verb"\hbox" and \verb"tabular" environment, to make sure the bounding box could be measured and the content could use normal \verb"\\" for breaking lines. But \verb"\par" is not acceptable so you should use the hard-breaking in the command parameter.
 %    \begin{macrocode}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -171,10 +171,10 @@
 %
 %  \begin{macro}{\secondaryinstlogo}
 %  Logo with secondary institute.
-%  The first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name. SHOULD BE NO \verb"\\".
-%  The second mandantory parameter is the main name for your institute. when the optional paramter is empty, you COULD USE \verb"\\" as linebreaks. BUT NOT \verb"\par".
-%  The third parameter is the logo of the left side, you could leave it as empty but mandantory.
-%  By default, this combination will occupy the whole row.
+%  The first optional parameter is typically the English name for your institute. If it exists (Chinese style), will be typesetted below the main name. THERE SHOULD BE NO \verb"\\".
+%  The second mandantory parameter is the main name for your institute. when the optional paramter is empty (English style), YOU COULD USE \verb"\\" as linebreaks. BUT NO \verb"\par" is allowed.
+%  The third parameter is the logo on the left side, you could leave it as empty but it is mandantory.
+%  When it is in English style (no optional parameter), you could use a secondary logo picture as your institute, but remember to resize the height to 0.95cm.
 %    \begin{macrocode}
 \newcommand*{\secondaryinstlogo}[3][]{%
   % #1: shortinst (optional)
@@ -234,7 +234,7 @@
           }%
           \vskip-2pt%
 %    \end{macrocode}
-%   In this way, the behavior like textbox in MS Word could be achieved, with the combination of \verb"\hbox" and \verb"tabular" environment, to make sure the bounding box could be measured and the content could use normal \verb"\\" for breaking lines. But \verb"\par" is not acceptable so you should use the hard-breaking in the command parameter.
+%   In this way, the behavior like textbox in MS Word could be achieved, with the combination of \verb"\hbox" and \verb"tabular" environment, to make sure the bounding box could be measured and the content could use normal \verb"\\" for breaking lines. But \verb"\par" is not acceptable so you should use the hard-breaking in the command parameter. If \verb"p{}" is used for enabling the \verb"\par", the width can not be automatically calculated and always be the specified width.
 %   But the benefit is also obvious, the width could be controlled and no more overfull hbox when inserting the institute. Since a \verb"\vbox" without \verb"\hsize" will make a box that occupy the whole line, but the width of the box should not be limited inexplicitly (no rule in SJTU VI). Futhermore, An alternative of using \verb"\parbox" has the same issue.
 %    \begin{macrocode}
           \vfill%
@@ -257,12 +257,14 @@
 %    \end{macrocode}
 %   Use \verb"\hbox" to make sure the width of the box is measurable.
 %   \verb"\mdseries" will make sure that the font weight will not be influenced by the current configuration.
-%   A thin space between the line is inserted.
 %    \begin{macrocode}
           \hbox{%
             \fontsize{13pt}{0pt}\selectfont%
             \mdseries\sffamily #2%
           }
+%    \end{macrocode}
+%   A thin space between the line is inserted.
+%    \begin{macrocode}
           \vskip0.08cm%
           \hbox{%
             \fontsize{5pt}{0pt}\selectfont%

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -111,6 +111,11 @@
 %    \end{macrocode}
 %
 % \subsubsection{Declare Logo}
+%   Aquire package \verb"array" for better control on \verb"tabular".
+%    \begin{macrocode}
+\RequirePackage{array}
+%    \end{macrocode}
+%
 % \begin{macro}{\definelogo}
 %    Define a mask picture to make its different color variants.
 %    The first argument assigns the file name and the second sets the horizontal cropping and the third sets the vertical cropping. Notice that the cropping is symmetrical (double the length). When the horizontal cropping is greater than the vertical cropping, the mask will be placed by its height, otherwise by its width. The domain for both cropping parameters is 0 to 1.
@@ -167,7 +172,7 @@
 %  \begin{macro}{\secondaryinstlogo}
 %  Logo with secondary institute.
 %  The first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name.
-%  The macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \verb"\\".
+%  The macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \verb"\\" but NOT \verb"\par".
 %  The second mandantory parameter is the main name for your institute.
 %  The third parameter is the logo of the left side, you could leave it as empty but mandantory.
 %  By default, this combination will occupy the whole row.
@@ -208,16 +213,26 @@
 %    \end{macrocode}
 %   You need to manually break the line for the main English name. The whole name will be typesetted centered vertically.
 %    \begin{macrocode}
-        \vbox to 1cm{\hsize 7cm%
+        \vbox to 1cm{%
           \vfill%
 %    \end{macrocode}
-%   Here, \verb"\baselineskip" is set to 0pt, which will always violate the rule that border distance between two lines should be greater than \verb"\lineskiplimit".
-%   And the \verb"\lineskip" will be applied to enlarge the distance. In this manner, the adjustment will be font-size free.
+%   Start a \verb"\hbox" inside the \verb"\vbox" to make sure that the box has a width that matches the content.
+%    \begin{macrocode}
+          \hbox{%
+%    \end{macrocode}
 %   Since \verb"\scshape" may not contain the boldface font weight, we manually set the font weight to \verb"\mdseries" to avoid the influence from the outside.
 %    \begin{macrocode}
-          \baselineskip 0pt\lineskip 2pt%
-          \noindent%
-          \fontsize{7.5pt}{0pt}\selectfont\mdseries\scshape #2%
+            \noindent%
+            \fontsize{7.5pt}{0pt}\selectfont\mdseries\scshape%
+%    \end{macrocode}
+%   Since the parameter could contain the breaklines \verb"\\", which is not function in the horizontal mode. To make the thing work, wrap it into the \verb"tabular" environment, and remove the left-right padding by \verb"@{}". Then the paramter could break lines.
+%   FIXME: Now it uses a phantom comma to emulate the a certain depth to increase the line height.
+%    \begin{macrocode}
+            \begin{tabular}{@{}l<{\vphantom{,}}@{}}#2\end{tabular}%
+          }%
+%    \end{macrocode}
+%   In this way, the behavior like textbox in MS Word could be achieved, with the combination of \verb"\hbox" and \verb"tabular" environment, to make sure the bounding box could be measured and the content could use normal \verb"\\" for breaking lines. But \verb"\par" is not acceptable so you should use the hard-breaking in the command parameter.
+%    \begin{macrocode}
           \vfill%
         }%
       \else%
@@ -231,6 +246,9 @@
         \vbox to 1cm{%
           \vfill
           \offinterlineskip
+%    \end{macrocode}
+%   Use \verb"\hbox" to make sure the width of the box is measurable.
+%    \begin{macrocode}
           \hbox{%
             \fontsize{13pt}{0pt}\selectfont%
             \mdseries\sffamily #2%
@@ -240,6 +258,9 @@
             \fontsize{5pt}{0pt}\selectfont%
             \scshape #1%
           }
+%    \end{macrocode}
+%   \verb"\prevdepth" is used to reduce the bottom padding by the depth of the previous line in case that the line has a comma.
+%    \begin{macrocode}
           \vskip-\prevdepth\vskip0.14cm%
         }%
       \fi

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -213,10 +213,11 @@
 %    \end{macrocode}
 %   Here, \verb"\baselineskip" is set to 0pt, which will always violate the rule that border distance between two lines should be greater than \verb"\lineskiplimit".
 %   And the \verb"\lineskip" will be applied to enlarge the distance. In this manner, the adjustment will be font-size free.
+%   Since \verb"\scshape" may not contain the boldface font weight, we manually set the font weight to \verb"\mdseries" to avoid the influence from the outside.
 %    \begin{macrocode}
           \baselineskip 0pt\lineskip 2pt%
           \noindent%
-          \fontsize{7.5pt}{0pt}\selectfont\scshape #2%
+          \fontsize{7.5pt}{0pt}\selectfont\mdseries\scshape #2%
           \vfill%
         }%
       \else%
@@ -229,7 +230,7 @@
         \fi%
         \vbox{%
           \fontsize{13pt}{0pt}\selectfont
-          \sffamily #2
+          \mdseries\sffamily #2
           \par\noindent\vskip0.14em
           \fontsize{5pt}{0pt}\selectfont
           \scshape #1

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -221,12 +221,12 @@
           \hbox{%
 %    \end{macrocode}
 %   Since \verb"\scshape" may not contain the boldface font weight, we manually set the font weight to \verb"\mdseries" to avoid the influence from the outside.
-%   And there is no obvious rule about the font size of English institute. Choose a similar one for approporiate look.
+%   And there is no explicit rule about the font size of the English institute. Choose a similar one for approporiate look.
 %    \begin{macrocode}
             \noindent%
             \fontsize{7pt}{0pt}\selectfont\mdseries\scshape%
 %    \end{macrocode}
-%   Since the parameter could contain the breaklines \verb"\\", which is not function in the horizontal mode. To make the thing work, wrap it into the \verb"tabular" environment, and remove the left-right padding by \verb"@{}". Then the paramter could break lines.
+%   Since the parameter could contain the breaklines \verb"\\", which is not functional in the horizontal mode. To make the thing work, wrap it into the \verb"tabular" environment, and remove the left-right padding by \verb"@{}". Then the paramter could break lines.
 %   To increase the interlineskip in tabular, use a phantom vrule at the end of each line with the depth of 2pt. At the end of the tabular, we should decrease the vskip by 2pt since the last line should not have that depth to make sure the content is vertically centered.
 %    \begin{macrocode}
             \begin{tabular}{@{}l<{\vphantom{\vrule depth2pt}}@{}}
@@ -236,6 +236,7 @@
           \vskip-2pt%
 %    \end{macrocode}
 %   In this way, the behavior like textbox in MS Word could be achieved, with the combination of \verb"\hbox" and \verb"tabular" environment, to make sure the bounding box could be measured and the content could use normal \verb"\\" for breaking lines. But \verb"\par" is not acceptable so you should use the hard-breaking in the command parameter.
+%   But the benefit is also obvious, the width could be controlled and no more overfull hbox when inserting the institute. Since a \verb"\vbox" without \verb"\hsize" will make a box that occupy the whole line, but the width of the box should not be limited inexplicitly (no rule in SJTU VI). Futhermore, An alternative of using \verb"\parbox" has the same issue.
 %    \begin{macrocode}
           \vfill%
         }%
@@ -248,10 +249,16 @@
           {\hskip0.23cm\vrule width0.5pt}\hskip0.23cm%
         \fi%
         \vbox to 1cm{%
+%    \end{macrocode}
+%   Align the institute component to the bottom of the current vbox.
+%   And remove the interlineskip for precise measurement.
+%    \begin{macrocode}
           \vfill
           \offinterlineskip
 %    \end{macrocode}
 %   Use \verb"\hbox" to make sure the width of the box is measurable.
+%   \verb"\mdseries" will make sure that the font weight will not be influenced by the current configuration.
+%   A thin space between the line is inserted.
 %    \begin{macrocode}
           \hbox{%
             \fontsize{13pt}{0pt}\selectfont%
@@ -272,6 +279,7 @@
   }
 }
 %    \end{macrocode}
+%  NOTE: For the optional parameter, \verb"\insertshortinsititute" in beamer class will first call \verb"\beamer@setupshort" to locally redefine \verb"\\" to empty, then the inserted text will not contain the breaklines. To insert the version with the breaklines, \verb"\beamer@shortinstitute" should be used.
 %  \end{macro}
 %
 % \subsubsection{Shape Declarations}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -171,9 +171,8 @@
 %
 %  \begin{macro}{\secondaryinstlogo}
 %  Logo with secondary institute.
-%  The first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name.
-%  The macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \verb"\\" but NOT \verb"\par".
-%  The second mandantory parameter is the main name for your institute.
+%  The first optional parameter is typically the English name for your institute. If it exists, will be typesetted below the main name. SHOULD BE NO \verb"\\".
+%  The second mandantory parameter is the main name for your institute. when the optional paramter is empty, you COULD USE \verb"\\" as linebreaks. BUT NOT \verb"\par".
 %  The third parameter is the logo of the left side, you could leave it as empty but mandantory.
 %  By default, this combination will occupy the whole row.
 %    \begin{macrocode}
@@ -279,7 +278,9 @@
   }
 }
 %    \end{macrocode}
-%  NOTE: For the optional parameter, \verb"\insertshortinsititute" in beamer class will first call \verb"\beamer@setupshort" to locally redefine \verb"\\" to empty, then the inserted text will not contain the breaklines. To insert the version with the breaklines, \verb"\beamer@shortinstitute" should be used.
+%  NOTE: The macro is defined as a ``star'' form which means you could pass a parameter that has linebreak \verb"\\" but NOT \verb"\par".
+%  For the optional parameter, \verb"\insertshortinsititute" in beamer class will first call \verb"\beamer@setupshort" to locally redefine \verb"\\" to empty, then the inserted text will not contain the breaklines. To insert the version with the breaklines, \verb"\beamer@shortinstitute" should be used.
+%  And if you insert a picture as the secondary institute as the main parameter, resize it to a 0.95cm height one for vertical alignment. i.e., \verb"\resizebox{!}{0.95cm}{<pic>}".
 %  \end{macro}
 %
 % \subsubsection{Shape Declarations}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/07/19 v2.9.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/07/28 v2.9.2 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}
@@ -221,9 +221,10 @@
           \hbox{%
 %    \end{macrocode}
 %   Since \verb"\scshape" may not contain the boldface font weight, we manually set the font weight to \verb"\mdseries" to avoid the influence from the outside.
+%   And there is no obvious rule about the font size of English institute. Choose a similar one for approporiate look.
 %    \begin{macrocode}
             \noindent%
-            \fontsize{7.5pt}{0pt}\selectfont\mdseries\scshape%
+            \fontsize{7pt}{0pt}\selectfont\mdseries\scshape%
 %    \end{macrocode}
 %   Since the parameter could contain the breaklines \verb"\\", which is not function in the horizontal mode. To make the thing work, wrap it into the \verb"tabular" environment, and remove the left-right padding by \verb"@{}". Then the paramter could break lines.
 %   To increase the interlineskip in tabular, use a phantom vrule at the end of each line with the depth of 2pt. At the end of the tabular, we should decrease the vskip by 2pt since the last line should not have that depth to make sure the content is vertically centered.

--- a/src/testfiles/sjtuvi.lvt
+++ b/src/testfiles/sjtuvi.lvt
@@ -4,8 +4,6 @@
 \def\colorblock#1{
     #1\hfill\tikz{\draw[black,fill=#1] (-1,-0.25) rectangle (1,0.25);}\par
 }
-\usepackage{silence}
-\WarningFilter{latexfont}{Font shape}  % KNOWN WARNING
 \begin{document}
     \START
     \begin{frame}
@@ -46,10 +44,12 @@
         \end{tikzpicture}
         \stamptext{Test}
     \end{frame}
+    \OMIT
     \begin{frame}
         \frametitle{Secondary Institute Logo}
         \secondaryinstlogo{Institute}{\phantom{-}}
         \secondaryinstlogo[Institute]{INSTITUTE}{\phantom{-}}
     \end{frame}
+    \TIMO
     \END
 \end{document}

--- a/src/testfiles/sjtuvi.tlg
+++ b/src/testfiles/sjtuvi.tlg
@@ -4,5 +4,4 @@ Don't change this file in any respect.
 ]
 \s=\skip...
 [3
-] [4
 ]


### PR DESCRIPTION
重构 `\secondaryinstlogo` 并正式可用。

```latex
% 中文样式
\secondaryinstlogo[英文名]{中文名}{徽标}
% 英文样式，此时英文名可用 \\ 换行，但不能用 \par 换行
\secondaryinstlogo{英文名}{徽标}
% 图片样式，图片高度需要为 0.95cm 高
\secondaryinstlogo{\resizebox{!}{0.95cm}{第二徽标}}{徽标}
```

细节：
- 使用 `tabular` 环境排印英文机构名可能的换行情况，这样将会自动设置该“文本框”的宽度。不再使用没有限定宽度的 `\vbox` 原语，这样可以让组合的边缘框宽度不会占满整行。不能使用 `\par` 换行的原因是 `tabular` 内部将 `\par` 置空，但又不能直接使用`p{}` 类型的单元格限定宽度，因为规定中并没有对于右侧宽度的限制。
- 现在必须依赖于 `array` 宏包，以在每一行之后插入设置行间空隙的命令（一个 2pt 深度的占位符），因为不能显式地在参数中设置诸如 `\\[2pt]` 的参数（这也将导致其他不是 `tabular` 的地方发生异常）。
- 但是使用 `\institute[]{}` 设置可以不用担心 `\\` 换行的情形，因为 beamer 在 [`\beamer@ststart`](https://github.com/josephwright/beamer/blob/865a19d4ec64f4c8e4935c19e162b8f4fd5aa190/base/beamerbasemisc.sty#L206) 宏中重定义了 `\\` 为空，当使用类似于 `\insertshortinstitute` 插入时会自动调用这一部分。所以仍然推荐使用 `\institute` 来设置。
- 使用 `\mdseries` 避免机构内的字重受到影响。
- 修复了 `\codeblockinput` 的 snippet 参数个数。

<img width="452" alt="image" src="https://user-images.githubusercontent.com/61653082/181378704-80507b67-8bda-496c-94b8-c5794f90867d.png">
