### PR TITLE
fix: reset stampblock counter in each frame

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -75,7 +75,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\n\\begin{stampblock",
 		"body": "\n\\begin{stampblock}<$3>[${1:}]{$2}\n\t$3\n\\end{stampblock}\n",
-		"description": "Create a block with title decorated by the stamp shape with incremental numbering.\nA mandantory parameter is needed for the title.\nAn optional parameter is for the customized numbering.\nOverlay could be specified.\n"
+		"description": "Create a block with title decorated by the stamp shape with incremental numbering.\nA mandantory parameter is needed for the title.\nAn optional parameter is for the customized numbering.\nOverlay could be specified. In this scenario, the optional parameter must be specified in case of the unexpected increment of the counter.\n"
 	},
 	"codeblock": {
 		"scope": "doctex,tex,latex",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}
@@ -196,6 +196,7 @@
   {\par%
     \usebeamertemplate{block stamp end}%
   \end{actionenv}}
+\AtBeginEnvironment{frame}{\setcounter{stampblockcnt}{0}}
 \lstset{
   basicstyle=\ttfamily\small,
   keywordstyle=\color{cprimary},%

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/08/27 v2.9.3 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/09/05 v2.9.4 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/08/27 v2.9.3 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/09/05 v2.9.4 Visual Identity System library for sjtubeamer]
 \def\DefineOption#1#2#3{%
   % #1: package
   % #2: key

--- a/src/build.lua
+++ b/src/build.lua
@@ -396,6 +396,13 @@ if options["target"] == "add-demo" then
                 end
                 return false
             end)
+
+            -- read sjtubeamer.tex
+            local usrdoc = docfiledir .. "/sjtubeamer.tex"
+            local usrdocfile = io.open(usrdoc, 'r')
+            local usrdoccontent = usrdocfile:read("a")
+            usrdocfile:close()
+
             for _, num in ipairs(actionlist) do
                 local oldid = num[2]
                 local num = num[1]
@@ -407,19 +414,17 @@ if options["target"] == "add-demo" then
                 local newid = string.gsub(oldid, num, num + 1)
                 ren(tutorialsuppdir, "step" .. oldid .. ".tex", "step" .. newid .. ".tex")
                 
-                -- modify the number in sjtubeamer.tex
-                local usrdoc = docfiledir .. "/sjtubeamer.tex"
-                local usrdocfile = io.open(usrdoc, 'r')
-                local usrdoccontent = usrdocfile:read("a")
-                usrdocfile:close()
+                -- modify the number in usr doc content.
                 local cnt
                 usrdoccontent, cnt = string.gsub(usrdoccontent, "step" .. string.gsub(string.gsub(oldid,"%+","%%+"),"%-","%%-") .. "%.", "step" .. newid .. ".") -- avoid the magical character insertion
-                local usrdocfile = io.open(usrdoc, "w+")
-                usrdocfile:write(usrdoccontent)
-                usrdocfile:close()
 
                 print("step" .. oldid .. " -> " .. "step" .. newid .. " Doc replaced: " .. cnt)
             end
+
+            -- write sjtubeamer.tex
+            local usrdocfile = io.open(usrdoc, "w+")
+            usrdocfile:write(usrdoccontent)
+            usrdocfile:close()
         end
 
         -- The new demo file will be created.

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -412,7 +412,8 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[1]{step13.tex}
 
 \begin{commentlist}
-  \item \env{stampblock} 用于生成印记区块环境，可以通过可选参数指定编号内容，可选参数缺省时为递增编号。该环境可以与 \env{columns} 配合使用，顶端对齐两列对比两种内容。必要时也可以添加覆盖参数，例如 \verb"<1>"。
+  \item \env{stampblock} 用于生成印记区块环境，可以通过可选参数指定编号内容，可选参数缺省时为每帧内部从 1 开始的递增编号。该环境可以与 \env{columns} 配合使用，顶端对齐两列对比两种内容。
+  \item 必要时也可以在可选参数前添加覆盖参数，例如 \verb"<1>[1]{标题}"。此时请指定可选参数编号内容 \verb"[1]"，否则覆盖帧内的区块编号也会意料外地递增。
 \end{commentlist}
 
 \chapter{代码}

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -436,7 +436,7 @@
 %  Create a block with title decorated by the stamp shape with incremental numbering.
 %  A mandantory parameter is needed for the title.
 %  An optional parameter is for the customized numbering.
-%  Overlay could be specified. In this scenario, the optional parameter must be specified in case of the increment of the counter.
+%  Overlay could be specified. In this scenario, the optional parameter must be specified in case of the unexpected increment of the counter.
 %    \begin{macrocode}
 \newcounter{stampblockcnt}
 %    \end{macrocode}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -436,7 +436,7 @@
 %  Create a block with title decorated by the stamp shape with incremental numbering.
 %  A mandantory parameter is needed for the title.
 %  An optional parameter is for the customized numbering.
-%  Overlay could be specified.
+%  Overlay could be specified. In this scenario, the optional parameter must be specified in case of the increment of the counter.
 %    \begin{macrocode}
 \newcounter{stampblockcnt}
 %    \end{macrocode}
@@ -477,6 +477,10 @@
   {\par%
     \usebeamertemplate{block stamp end}%
   \end{actionenv}}
+%    \end{macrocode}
+%  Finally, reset the \verb"stampblockcnt" counter at the beginning of each frame, since it is meaningless to keep the number continous among frames.
+%    \begin{macrocode}
+\AtBeginEnvironment{frame}{\setcounter{stampblockcnt}{0}}
 %    \end{macrocode}
 %  This macro is orginally prepared for poster. It is also useful for side-by-side comparision in one slide.
 %  COPYRIGHT NOTICE: Reference to code from beamr class and beamerauxtheme.

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/08/27 v2.9.3 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/09/05 v2.9.4 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/08/27 v2.9.3 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/09/05 v2.9.4 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/08/27 v2.9.3 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/09/05 v2.9.4 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
在每帧开始时重置 `stampblock` 的编号计数器，跨帧的编号递增是没有必要的。