### PR TITLE
style: fit poster, pre-release

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -69,7 +69,7 @@
 		"scope": "doctex,tex,latex",
 		"prefix": "\n\\begin{stampbox",
 		"body": "\n\\begin{stampbox}[${1:cprimary}]\n\t$2\n\\end{stampbox}\n",
-		"description": "Make a stampbox border, which is a decoration advice from SJTU VI. It has the dependency on stampline from sjtuvi package.\n"
+		"description": "Make a box with stampline border.\nThe optional paramter indicates the color of the border line.\n"
 	},
 	"stamphrule": {
 		"scope": "doctex,tex,latex",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}
@@ -171,10 +171,10 @@
   frame empty,
   interior empty,
   sharp corners,
-  top=0.2em,bottom=0.2em,left=0.2em,right=0.2em,
-  borderline={0.4em}{0em}{
+  top=0.24em,bottom=0.24em,left=0.24em,right=0.24em,
+  boxsep=0em,
+  borderline={0.05em}{0em}{
     #1,
-    line width=0.05em,
     decoration={
       stampline,
       segment length=0.8em,
@@ -184,7 +184,6 @@
   }
 }
 \newcommand{\stamphrule}[1][cprimary]{%
-  \leavevmode%
   \vskip-\prevdepth%
   \vskip0.5\baselineskip%
   {%

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}
@@ -50,7 +50,7 @@
         \begingroup
         \usebeamerfont{frametitle}
         \vbox{}
-        \ifx\insertframesubtitle\@empty\vskip-0.6ex%
+        \ifx\insertframesubtitle\@empty\vskip-0.55ex%
         \else\vskip-0.85ex\fi%
         \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
         \strut\insertframetitle\strut\par%
@@ -68,12 +68,12 @@
         \endgroup%
         \raggedleft%
         \begingroup
-        \ifx\insertframesubtitle\@empty\vskip-2.1ex%
-        \else\vskip-3.05ex\fi%
+        \ifx\insertframesubtitle\@empty\vskip-2.13ex%
+        \else\vskip-2.95ex\fi%
         \resizebox{!}{3ex}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{10pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
-        \else\vskip0.6ex\fi%
+        \else\vskip0.65ex\fi%
         \if@tempswa\else\vskip-.3cm\fi%
       \end{beamercolorbox}%
     }

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -50,8 +50,8 @@
         \begingroup
         \usebeamerfont{frametitle}
         \vbox{}
-        \ifx\insertframesubtitle\@empty\vskip-0.55ex%
-        \else\vskip-0.85ex\fi%
+        \ifx\insertframesubtitle\@empty\vskip-0.5ex%
+        \else\vskip-0.7ex\fi%
         \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
         \strut\insertframetitle\strut\par%
         {%
@@ -68,12 +68,12 @@
         \endgroup%
         \raggedleft%
         \begingroup
-        \ifx\insertframesubtitle\@empty\vskip-2.13ex%
-        \else\vskip-2.95ex\fi%
+        \ifx\insertframesubtitle\@empty\vskip-2.2ex%
+        \else\vskip-3.05ex\fi%
         \resizebox{!}{3ex}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{10pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
-        \else\vskip0.65ex\fi%
+        \else\vskip0.75ex\fi%
         \if@tempswa\else\vskip-.3cm\fi%
       \end{beamercolorbox}%
     }

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/contrib/poster/poster.tex
+++ b/contrib/poster/poster.tex
@@ -91,12 +91,8 @@
       \end{column}
     \end{columns}
 
-    % 分割线
-    \vspace*{2cm}
-    \begin{tikzpicture}
-      \draw[cprimary,decoration=stampline,segment length=1cm,decorate] (0,0) -- (0.94\textwidth,0);
-    \end{tikzpicture}
-    \vspace*{2cm}
+    % 正文中的分割线使用 \posterstamphrule
+    \posterstamphrule[cprimary]
 
     \begin{columns}
       \begin{column}{0.45\textwidth}
@@ -134,6 +130,8 @@
           \end{column}
           \begin{column}{.5\textwidth}
             $\leftarrow$ 你仍然可以使用 \texttt{stampbox} 环境插入带边框的图片\vspace{1ex}
+            % column 环境中的分割线仍然使用 \stamphrule
+            \stamphrule
           \end{column}
         \end{columns}
       \end{column}

--- a/contrib/poster/sjtubeamerthemeposter.ltx
+++ b/contrib/poster/sjtubeamerthemeposter.ltx
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 % 设置文件元数据
-\ProvidesFile{sjtubeamerthemeposter.ltx}[2022/09/20 Beamerposter adapter for SJTUBeamer]
+\ProvidesFile{sjtubeamerthemeposter.ltx}[2022/10/18 Beamerposter adapter for SJTUBeamer]
 \PassOptionsToPackage{orientation=portrait}{beamerposter}
 \if\EqualOption{poster}{landscape}{true}
   \PassOptionsToPackage{orientation=landscape}{beamerposter}
@@ -143,6 +143,18 @@
 }
 \setbeamertemplate{block example end}{
   \end{beamercolorbox}
+}
+% 在正文环境内（不包含小栏）
+% 需要使用 \posterstamphrule[cprimary] 插入较短的分割线。
+% 该分割线自带两边 2ex 的纵向间距。
+\newcommand{\posterstamphrule}[1][cprimary]{%
+  \vskip2ex%
+  \vskip-0.5\baselineskip%
+  \begin{minipage}{0.94\textwidth}%
+    \leavevmode%
+    \stamphrule[#1]%
+  \end{minipage}%
+  \vskip2ex%
 }
 % tcolorbox 设定
 \tcbset{toptitle=2.5mm,bottomtitle=2.5mm}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/10/17 v2.9.8 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/10/19 v2.9.9 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}
@@ -178,12 +178,12 @@
   \usebeamercolor{palette primary}%
   \ifx\inserttitlegraphic\@empty%
   \else
-    \begin{tikzpicture}[overlay,yshift=0.77em]
-      \node (pic) [fg, above left] at (0.88*\the\paperwidth,0)
+    \begin{tikzpicture}[overlay, yshift=1.2em]
+      \node (pic) [fg, above left, inner sep=0.32em] at (0.86\paperwidth,0)
       {\resizebox{0.3\paperwidth}{!}{\inserttitlegraphic}};
       \draw[decoration={
             stampline,
-            segment length=8pt,
+            segment length=0.8em,
             path has corners=true,
           },decorate,fg]
       (pic.north west) --

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/10/17 v2.9.8 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/10/19 v2.9.9 Visual Identity System library for sjtubeamer]
 \newif\ifsjtubeamer@tempif%
 \newbox\sjtubeamer@tempbox%
 \newskip\sjtubeamer@h%

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -431,7 +431,7 @@ fontupper=\sffamily,colupper=white}
 \beamerdemo[1]{step14.tex}
 
 \begin{commentlist}
-  \item \cmd{stamphrule} 用来生成一个水平印记分割线，类似于 \cmd{hrule}。
+  \item \cmd{stamphrule} 用来生成一个水平印记分割线，类似于 \cmd{hrule}。可以添加可选参数用于指定分割线颜色，如 \cmd{stamphrule[sjtuBluePrimary]}。
   \item 两个 \env{column} 之间可以使用 \cmd{vrule} 产生竖直分割线隔开，紧随其后的 \cmd{hfill} 是必要的，这样这个竖直分割线才能水平居中。
   \item 这里使用了 \cmd{textcolor} 来设置竖直分割线的颜色。
 \end{commentlist}

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -220,7 +220,7 @@ If you are a Windows user\footnote{Windows 10 users could also install WSL (Wind
     \end{verbatim}
 and copy the corresponding generated files to the root directory.
 
-\subsection{Continous Integration}
+\subsection{Continuous Integration}
 
 All other scripts in the folder \verb".github/ci" could also be checked in your local machine to make sure you can pass the CI on GitHub Actions.
 

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -438,7 +438,8 @@
 % \end{macro}
 %
 % \begin{macro}{stampbox}
-%   Make a stampbox border, which is a decoration advice from SJTU VI. It has the dependency on \verb"stampline" from \verb"sjtuvi" package.
+%   Make a box with stampline border.
+%   The optional paramter indicates the color of the border line.
 %    \begin{macrocode}
 \newtcolorbox{stampbox}[1][cprimary]{%
   capture=hbox,
@@ -446,10 +447,10 @@
   frame empty,
   interior empty,
   sharp corners,
-  top=0.2em,bottom=0.2em,left=0.2em,right=0.2em,
-  borderline={0.4em}{0em}{
+  top=0.24em,bottom=0.24em,left=0.24em,right=0.24em,
+  boxsep=0em,
+  borderline={0.05em}{0em}{
     #1,
-    line width=0.05em,
     decoration={
       stampline,
       segment length=0.8em,
@@ -459,6 +460,9 @@
   }
 }
 %    \end{macrocode}
+%  NOTE: It is a decoration advice from SJTU VI. It has the dependency on \verb"stampline" from \verb"sjtuvi" package.
+%  SJTU VI regulates that the padding of the stampbox should be the twice the height of the stamp element. According to the definition from \verb"sjtuvi", the height of the element will be $0.2\times$segement width, or here is 0.16em, i.e., the total padding should be 0.32em. However, when using \verb"borderline" to draw the border, the base padding will be the same height of the line decoration, i.e., 0.08em. As a result, the padding should be $0.32-0.08=0.24$ em. With the \verb"boxsep" set to 0em (to avoid extra padding).
+%  The line width of the stampline has been indicated by the first paramter of the borderline and should not be put in the third paramter.
 % \end{macro}
 %
 % \begin{macro}{\stamphrule}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -467,10 +467,7 @@
 %    \begin{macrocode}
 \newcommand{\stamphrule}[1][cprimary]{%
 %    \end{macrocode}
-%  In case it is not the horizontal mode.
-%    \begin{macrocode}
-  \leavevmode%
-%    \end{macrocode}
+%  It is not necessary to \verb"\leavevmode" here, which may cause extra space if there is a blank line before this command.
 %  Eliminate the previous depth to avoid inconsistency.
 %    \begin{macrocode}
   \vskip-\prevdepth%
@@ -507,7 +504,6 @@
 }
 %    \end{macrocode}
 %  NOTE: As a matter of fact, the user could pass more paramters to the \verb"\draw" command other than the color.
-%  FIXME: It still behaves differently with \verb"\hrule" in \verb"poster" subtheme, \verb"\hsize" will be too large.
 % \end{macro}
 %  You may wonder why there is no \verb"\stampvrule". It is because the current line width is easy to be accessed by \verb"\hsize". And \verb"\stamphrule" is just an emulation of \verb"\hrule". However, \verb"\vsize" is the page height. \verb"\vrule" is a \TeX{} primitive where the default for height is the height of the enclosing \verb"\hbox". The developer could not implement it in this macro-programming layer. The developer could only get the previous depth by \verb"\prevdepth" at best (and it is not usable in restricted horizontal mode). The user could make a vertical line in the \verb"columns" environment and between \verb"column" environments like this:
 %  \begin{verbatim}\vrule\hfill\end{verbatim}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -92,8 +92,8 @@
 %    \end{macrocode}
 %   Lift the left part a little bit.
 %    \begin{macrocode}
-        \ifx\insertframesubtitle\@empty\vskip-0.55ex%
-        \else\vskip-0.85ex\fi%
+        \ifx\insertframesubtitle\@empty\vskip-0.5ex%
+        \else\vskip-0.7ex\fi%
         \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
         \strut\insertframetitle\strut\par%
         {%
@@ -113,15 +113,15 @@
 %    \begin{macrocode}
         \raggedleft%
         \begingroup
-        \ifx\insertframesubtitle\@empty\vskip-2.13ex%
-        \else\vskip-2.95ex\fi%
+        \ifx\insertframesubtitle\@empty\vskip-2.2ex%
+        \else\vskip-3.05ex\fi%
 %    \end{macrocode}
 % Insert the outer logo with 3ex height. \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input. The calculation is fixed for a 3ex height logo placeholder.
 %    \begin{macrocode}
         \resizebox{!}{3ex}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{10pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
-        \else\vskip0.65ex\fi%
+        \else\vskip0.75ex\fi%
         \if@tempswa\else\vskip-.3cm\fi%
       \end{beamercolorbox}%
     }

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -92,7 +92,7 @@
 %    \end{macrocode}
 %   Lift the left part a little bit.
 %    \begin{macrocode}
-        \ifx\insertframesubtitle\@empty\vskip-0.6ex%
+        \ifx\insertframesubtitle\@empty\vskip-0.55ex%
         \else\vskip-0.85ex\fi%
         \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
         \strut\insertframetitle\strut\par%
@@ -113,15 +113,15 @@
 %    \begin{macrocode}
         \raggedleft%
         \begingroup
-        \ifx\insertframesubtitle\@empty\vskip-2.1ex%
-        \else\vskip-3.05ex\fi%
+        \ifx\insertframesubtitle\@empty\vskip-2.13ex%
+        \else\vskip-2.95ex\fi%
 %    \end{macrocode}
 % Insert the outer logo with 3ex height. \verb"\vphantom" here is to create a phantom box to make sure the \verb"\resizebox" has a non-zero height box input. The calculation is fixed for a 3ex height logo placeholder.
 %    \begin{macrocode}
         \resizebox{!}{3ex}{\vphantom{-}\usebeamertemplate{logo}}\hspace*{10pt}%
         \endgroup%
         \ifx\insertframesubtitle\@empty%
-        \else\vskip0.6ex\fi%
+        \else\vskip0.65ex\fi%
         \if@tempswa\else\vskip-.3cm\fi%
       \end{beamercolorbox}%
     }

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/10/17 v2.9.8 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2022/10/19 v2.9.9 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -276,16 +276,17 @@
   \end{beamercolorbox}
 %    \end{macrocode}
 %   Here insert the titlegraphic. The node position is set to \verb"above left" to make sure the bottom of the picture is aligned to the bottom of the date line.
+%   The size specification should be the same as \verb"stampbox" in the inner theme. Since we need a finer control on the position of the picture and the inner theme is the upper layer of this style file, the whole thing should be reimplemented here.
 %    \begin{macrocode}
   \usebeamercolor{palette primary}% 
   \ifx\inserttitlegraphic\@empty%
   \else
-    \begin{tikzpicture}[overlay,yshift=0.77em]
-      \node (pic) [fg, above left] at (0.88*\the\paperwidth,0)
+    \begin{tikzpicture}[overlay, yshift=1.2em]
+      \node (pic) [fg, above left, inner sep=0.32em] at (0.86\paperwidth,0)
       {\resizebox{0.3\paperwidth}{!}{\inserttitlegraphic}};
       \draw[decoration={
             stampline,
-            segment length=8pt,
+            segment length=0.8em,
             path has corners=true,
           },decorate,fg]
       (pic.north west) --

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/10/17 v2.9.8 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2022/10/19 v2.9.9 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/10/17 v2.9.8 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2022/10/19 v2.9.9 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
主要作样式调整：
- [x] 去除 `\stamphrule` 中的 `\leavevmode`。
- [x] 修复 `stampbox` 的内边距。
- [x] 同步 min title page 的 stampbox。
- [x] 对 frametitle 做微小修正。
- [x] 向 `poster` 中添加 `\posterstamphrule` 以添加海报正文的分割线。
- [x] 修补 `\partpage` 编译慢（来自 #110）

预计在下一个 PR 发布大版本 3.0.0，将不做功能性更新，关注代码质量与文档质量的整体提升。本版本作为预发布版本，将尽可能多地修复功能性问题。