### PR TITLE
ci: l3build add-contrib [ci skip]

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -16,6 +16,7 @@ name: Contrib
 jobs:
   build-contrib:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'contrib skip')"
     # permission to the environment will 
     # need to be approved by one of the collaborators
     environment: IMGUR

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -16,6 +16,8 @@ name: Contrib
 jobs:
   build-contrib:
     runs-on: ubuntu-latest
+    # ignore the commit with [contrib skip] tag.
+    if: "!contains(github.event.head_commit.message, 'contrib skip')"
     # permission to the environment will 
     # need to be approved by one of the collaborators
     environment: IMGUR
@@ -24,10 +26,6 @@ jobs:
         name: checkout code
         with:
           fetch-depth: 0
-      - uses: mstachniuk/ci-skip@v1
-        with:
-          commit-filter: 'contrib skip;skip contrib'
-          commit-filter-separator: ';'
       - name: get newly contributed package (pull request)
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -16,6 +16,7 @@ name: Contrib
 jobs:
   build-contrib:
     runs-on: ubuntu-latest
+    # ignore the commit with [contrib skip] tag.
     if: "!contains(github.event.head_commit.message, 'contrib skip')"
     # permission to the environment will 
     # need to be approved by one of the collaborators

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -16,8 +16,6 @@ name: Contrib
 jobs:
   build-contrib:
     runs-on: ubuntu-latest
-    # ignore the commit with [contrib skip] tag.
-    if: "!contains(github.event.head_commit.message, 'contrib skip')"
     # permission to the environment will 
     # need to be approved by one of the collaborators
     environment: IMGUR
@@ -26,6 +24,10 @@ jobs:
         name: checkout code
         with:
           fetch-depth: 0
+      - uses: mstachniuk/ci-skip@v1
+        with:
+          commit-filter: 'contrib skip;skip contrib'
+          commit-filter-separator: ';'
       - name: get newly contributed package (pull request)
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -16,8 +16,6 @@ name: Contrib
 jobs:
   build-contrib:
     runs-on: ubuntu-latest
-    # ignore the commit with [contrib skip] tag.
-    if: "!contains(github.event.head_commit.message, 'contrib skip')"
     # permission to the environment will 
     # need to be approved by one of the collaborators
     environment: IMGUR

--- a/contrib/minted/sjtubeamerthememinted.ltx
+++ b/contrib/minted/sjtubeamerthememinted.ltx
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2022 LogCreative
+%% Copyright (C) 2022 LogCreative <logcreative@outlook.com>
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/contrib/poster/sjtubeamerthemeposter.ltx
+++ b/contrib/poster/sjtubeamerthemeposter.ltx
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2022 LogCreative
+%% Copyright (C) 2022 LogCreative <logcreative@outlook.com>
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/contrib/sjtug/sjtubeamerthemesjtug.ltx
+++ b/contrib/sjtug/sjtubeamerthemesjtug.ltx
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2022 LogCreative
+%% Copyright (C) 2022 LogCreative <logcreative@outlook.com>
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/build.lua
+++ b/src/build.lua
@@ -458,7 +458,7 @@ if options["target"] == "add-contrib" then
             -- make plugin directory
             mkdir(plugindir)
 
-            -- generate plugin document itself
+            -- generate plugin itself
             cp("sjtubeamerthemenewcontrib.template.ltx", supportdir, plugindir)
             ren(plugindir, "sjtubeamerthemenewcontrib.template.ltx", "sjtubeamertheme" .. pluginname .. ".ltx")
             local pluginpath = plugindir .. "/" .. "sjtubeamertheme" .. pluginname .. ".ltx"
@@ -506,6 +506,9 @@ if options["target"] == "add-contrib" then
             print(pluginname .. " plugin is created.")
             print("  > Plugin itself: " .. pluginpath)
             print("  > Plugin documentation: " ..plugindocpath)
+            print("To debug the plugin, install the current version of sjtubeamer globally first by:")
+            print("  l3build install")
+            print("Then compile the documentation in the contrib directory: " .. plugindir)
         else
             print("Error: " .. pluginname .. " has already existed.")
             os.exit(1)

--- a/src/build.lua
+++ b/src/build.lua
@@ -469,11 +469,14 @@ if options["target"] == "add-contrib" then
                         "0000/00/00",os.date("%Y/%m/%d")),
                             "newcontrib", pluginname
                 )
-            local author = io.popen("git config --get user.name",'r')  -- get author info
-            if author ~= nil then
-                pluginfilecontent = string.gsub(pluginfilecontent, '<author>', author:read('*a'))
+            local errorlevel = os.execute("git --version")
+            if errorlevel == 0 then
+                local author = io.popen("git config --get user.name",'r')  -- get author info
+                if author ~= nil then
+                    pluginfilecontent = string.gsub(pluginfilecontent, '<author>', author:read('*a'))
+                end
+                author:close()
             end
-            author:close()
             pluginfile = io.open(pluginpath, 'w')
             pluginfile:write(pluginfilecontent)
             pluginfile:close()

--- a/src/build.lua
+++ b/src/build.lua
@@ -469,13 +469,21 @@ if options["target"] == "add-contrib" then
                         "0000/00/00",os.date("%Y/%m/%d")),
                             "newcontrib", pluginname
                 )
+            -- get information from git
+            -- no swap when no git
+            print('Trying to get author and email information from:')
             local errorlevel = os.execute("git --version")
             if errorlevel == 0 then
                 local author = io.popen("git config --get user.name",'r')  -- get author info
                 if author ~= nil then
-                    pluginfilecontent = string.gsub(pluginfilecontent, '<author>', author:read('*a'))
+                    pluginfilecontent = string.gsub(pluginfilecontent, '<author>', author:read('*l'))
                 end
                 author:close()
+                local email = io.popen("git config --get user.email",'r') -- get author email
+                if email ~= nil then
+                    pluginfilecontent = string.gsub(pluginfilecontent, '<email>', '<' .. email:read('*l') .. '>')
+                end
+                email:close()
             end
             pluginfile = io.open(pluginpath, 'w')
             pluginfile:write(pluginfilecontent)

--- a/src/build.lua
+++ b/src/build.lua
@@ -471,7 +471,7 @@ if options["target"] == "add-contrib" then
                 )
             local author = io.popen("git config --get user.name",'r')  -- get author info
             if author ~= nil then
-                pluginfilecontent = string.gsub(pluginfilecontent, '<Author>', author:read('*a'))
+                pluginfilecontent = string.gsub(pluginfilecontent, '<author>', author:read('*a'))
             end
             author:close()
             pluginfile = io.open(pluginpath, 'w')

--- a/src/build.lua
+++ b/src/build.lua
@@ -412,7 +412,9 @@ if options["target"] == "add-demo" then
                 
                 -- modify the number in usr doc content.
                 local cnt
-                usrdoccontent, cnt = string.gsub(usrdoccontent, "step" .. string.gsub(string.gsub(oldid,"%+","%%+"),"%-","%%-") .. "%.", "step" .. newid .. ".") -- avoid the magical character insertion
+                usrdoccontent, cnt = string.gsub(usrdoccontent, "step" .. 
+                string.gsub(string.gsub(oldid,"%+","%%+"),"%-","%%-") .. 
+                "%.", "step" .. newid .. ".") -- avoid the magical character insertion
 
                 print("step" .. oldid .. " -> " .. "step" .. newid .. " Doc replaced: " .. cnt)
             end
@@ -434,5 +436,69 @@ if options["target"] == "add-demo" then
     end
 
     adddemo(demonum)
+    os.exit(0)
+end
+
+-- usage: l3build add-contrib [pluginname]
+-- description: initialize a plugin called [pluginname].
+if options["target"] == "add-contrib" then
+    if options["names"] == nil or #options["names"] > 1 then
+        print("Error: Please specify one and only one contrib name. (" .. module .. ")")
+        os.exit(1)
+    end
+
+    local pluginname = options["names"][1]
+
+    local function addcontrib(pluginname)
+        local contribdir = "../contrib"
+        local plugindir = contribdir .. "/" .. pluginname
+        if not direxists(plugindir) then
+            -- make plugin directory
+            mkdir(plugindir)
+
+            -- generate plugin document itself
+            cp("sjtubeamerthemenewcontrib.template.ltx", supportdir, plugindir)
+            ren(plugindir, "sjtubeamerthemenewcontrib.template.ltx", "sjtubeamertheme" .. pluginname .. ".ltx")
+            local pluginpath = plugindir .. "/" .. "sjtubeamertheme" .. pluginname .. ".ltx"
+            local pluginfile = io.open(pluginpath, 'r')
+            local pluginfilecontent = pluginfile:read('a')
+            pluginfile:close()
+            pluginfilecontent = string.gsub(
+                string.gsub(
+                    string.gsub(pluginfilecontent, "<year>", os.date("%Y")),
+                        "0000/00/00",os.date("%Y/%m/%d")),
+                            "newcontrib", pluginname
+                )
+            local author = io.popen("git config --get user.name",'r')  -- get author info
+            if author ~= nil then
+                pluginfilecontent = string.gsub(pluginfilecontent, '<Author>', author:read('*a'))
+            end
+            author:close()
+            pluginfile = io.open(pluginpath, 'w')
+            pluginfile:write(pluginfilecontent)
+            pluginfile:close()
+
+            -- generate plugin documentation
+            cp("newcontrib.template.tex", supportdir, plugindir)
+            ren(plugindir, "newcontrib.template.tex", pluginname .. ".tex")
+            local plugindocpath = plugindir .. "/" .. pluginname .. ".tex"
+            local plugindocfile = io.open(plugindocpath, 'r')
+            local plugindoccontent = plugindocfile:read('a')
+            plugindocfile:close()
+            plugindoccontent = string.gsub(plugindoccontent, "newcontrib", pluginname)
+            plugindocfile = io.open(plugindocpath, 'w')
+            plugindocfile:write(plugindoccontent)
+            plugindocfile:close()
+
+            print(pluginname .. " plugin is created.")
+            print("  > Plugin itself: " .. pluginpath)
+            print("  > Plugin documentation: " ..plugindocpath)
+        else
+            print("Error: " .. pluginname .. " has already existed.")
+            os.exit(1)
+        end
+    end
+
+    addcontrib(pluginname)
     os.exit(0)
 end

--- a/src/build.lua
+++ b/src/build.lua
@@ -439,6 +439,9 @@ if options["target"] == "add-demo" then
     os.exit(0)
 end
 
+-- contrib directory
+contribdir = "../contrib"
+
 -- usage: l3build add-contrib [pluginname]
 -- description: initialize a plugin called [pluginname].
 if options["target"] == "add-contrib" then
@@ -450,7 +453,6 @@ if options["target"] == "add-contrib" then
     local pluginname = options["names"][1]
 
     local function addcontrib(pluginname)
-        local contribdir = "../contrib"
         local plugindir = contribdir .. "/" .. pluginname
         if not direxists(plugindir) then
             -- make plugin directory

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -191,6 +191,8 @@ The file will be generated based on the template \verb"support/step.template.tex
   \end{tabular}
 \end{table}
 
+\fcmd{l3build add-contrib test} This command will create a plugin called \texttt{test} in the directory \texttt{../contrib}. This command will grab the information from \texttt{git} to fill the blanks of ``author'' and ``email'' (left blank when no git is installed).
+
 \subsection{Customize Generation}\label{sec:precompile}
 
 In \verb"source/beamerthemesjtubeamer.ins", you could customize what templates you want to output on the line:

--- a/src/support/newcontrib.template.tex
+++ b/src/support/newcontrib.template.tex
@@ -1,0 +1,11 @@
+\documentclass{ctexbeamer}
+\usetheme{sjtubeamer}
+\usesjtutheme{newcontrib}
+\begin{document}
+    \begin{frame}
+        \frametitle{newcontrib 插件}
+
+        % 插件文档...
+
+    \end{frame}
+\end{document}

--- a/src/support/newcontrib.template.tex
+++ b/src/support/newcontrib.template.tex
@@ -2,10 +2,10 @@
 \usetheme{sjtubeamer}
 \usesjtutheme{newcontrib}
 \begin{document}
-    \begin{frame}
-        \frametitle{newcontrib 插件}
+\begin{frame}
+  \frametitle{newcontrib 插件}
 
-        % 插件文档...
+  % 插件文档...
 
-    \end{frame}
+\end{frame}
 \end{document}

--- a/src/support/sjtubeamerthemenewcontrib.template.ltx
+++ b/src/support/sjtubeamerthemenewcontrib.template.ltx
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) <year> <author>
+%% Copyright (C) <year> <author> <email>
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/support/sjtubeamerthemenewcontrib.template.ltx
+++ b/src/support/sjtubeamerthemenewcontrib.template.ltx
@@ -1,0 +1,21 @@
+%% ------------------------------------------------------------------------
+%% Copyright (C) <year> <author>
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% ------------------------------------------------------------------------
+% 文件元数据
+\ProvidesFile{sjtubeamerthemenewcontrib.ltx}[0000/00/00 newcontrib for sjtubeamer]
+% 传入选项的处理
+\if\EqualOption{newcontrib}{debug}{true}
+    \PackageInfo{You are debugging newcontrib}
+\fi


### PR DESCRIPTION
- [x] 添加 `l3build add-contrib test` 命令以方便添加插件。
- [x] 使用 `git` 获取作者与邮箱信息。
- [ ] 添加 `contrib skip` 标志用于跳过插件检查。