### PR TITLE
fix: if titlegraphic empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ int main(){
 
 目前模版最新的稳定版是 v3.0.0。您可以在 [发布页](https://github.com/sjtug/SJTUBeamer/releases) 查看修改日志和更多资料。通常来说，SJTUBeamer 的一个稳定版本包括如下内容：
 
-* `sjtubeamerquickguide.pdf`：SJTUBeamer 快速入门，另见对应 [源代码](https://github.com/sjtug/SJTUBeamer/blob/main/src/doc/sjtubeamerquickstart.tex)。
+* `sjtubeamerquickstart.pdf`：SJTUBeamer 快速入门，另见对应 [源代码](https://github.com/sjtug/SJTUBeamer/blob/main/src/doc/sjtubeamerquickstart.tex)。
 * `sjtubeamer.pdf`: **强烈推荐在使用前阅读一遍 👍👍👍** SJTUBeamer 用户文档。
 * `sjtubeamerdevguide.pdf`: SJTUBeamer 开发指南。
 * `sjtulib-talk-max-red.pdf`: 示例文档《如何使用 LaTeX 排版论文》的 `max,red` 主题版本。

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamercolorthemesjtubeamer.dtx  (with options: `package')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021,2022 SJTUG
+%% Copyright (C) 2021-2023 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamerfontthemesjtubeamer.dtx  (with options: `package')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021,2022 SJTUG
+%% Copyright (C) 2021-2023 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamerinnerthemesjtubeamer.dtx  (with options: `package,maxplus,max,min,my')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021,2022 SJTUG
+%% Copyright (C) 2021-2023 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamerouterthemesjtubeamer.dtx  (with options: `package')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021,2022 SJTUG
+%% Copyright (C) 2021-2023 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamerthemesjtubeamer.dtx  (with options: `package,maxplus,max,min,my')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021,2022 SJTUG
+%% Copyright (C) 2021-2023 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/contents/thesis.tex
+++ b/contents/thesis.tex
@@ -74,15 +74,15 @@
 \begin{frame}[fragile]{模板选项}
   \begin{description}
     \item[type] 指定论文类型（本科/硕士/博士/课程）
-      \begin{lstlisting}[basicstyle=\ttfamily]
+          \begin{lstlisting}[basicstyle=\ttfamily]
 \documentclass[type=bachelor]{sjtuthesis}
   \end{lstlisting}
     \item[review] 开启盲审模式
-      \begin{lstlisting}[basicstyle=\ttfamily]
+          \begin{lstlisting}[basicstyle=\ttfamily]
 \documentclass[type=master,review]{sjtuthesis}
   \end{lstlisting}
     \item[fontset] 指定字体（推荐使用 \verb|windows|）
-      \begin{lstlisting}[basicstyle=\ttfamily]
+          \begin{lstlisting}[basicstyle=\ttfamily]
 \documentclass[type=doctor,fontset=windows]{sjtuthesis}
   \end{lstlisting}
   \end{description}

--- a/contrib/sjtug/sjtug.tex
+++ b/contrib/sjtug/sjtug.tex
@@ -17,7 +17,7 @@
 
   \begin{description}
     \item[\texttt{debug}] 参数可以在使用 Lua\LaTeX{} 编译时调用 \texttt{lua-visual-debug}
-      宏包显示区块边界。
+          宏包显示区块边界。
   \end{description}
 \end{frame}
 \makebottom

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/11/25 v3.0.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2023/11/25 v3.0.1 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -86,7 +86,7 @@
     rectangle (1*\the\paperwidth, 0.3*\the\paperheight);
     \node [palette primary.fg, inner sep=0pt]
     at (0.45\paperwidth-6pt,-0.4*\the\paperheight)
-    {\resizebox{1.3\paperwidth}{!}{\inserttitlegraphic}};
+    {\resizebox{1.3\paperwidth}{!}{\vphantom{-}\inserttitlegraphic}};
   \end{tikzpicture}
   \vfill
   \begingroup
@@ -176,8 +176,7 @@
     \usebeamerfont{date}\insertdate
   \end{beamercolorbox}
   \usebeamercolor{palette primary}%
-  \ifx\inserttitlegraphic\@empty%
-  \else
+  \ifbeamertemplateempty{titlegraphic}{}{%
     \begin{tikzpicture}[overlay, yshift=1.2em]
       \node (pic) [fg, above left, inner sep=0.32em] at (0.86\paperwidth,0)
       {\resizebox{0.3\paperwidth}{!}{\inserttitlegraphic}};
@@ -191,7 +190,7 @@
       (pic.south east) --
       (pic.south west) -- cycle;
     \end{tikzpicture}
-  \fi
+  }
   \endgroup
   \vskip0.5em
   \vfill
@@ -231,7 +230,7 @@
         \clip (-0.66\paperwidth,0.06\paperheight)
         rectangle (0.43\paperwidth,0.53\paperheight);
         \node [anchor=north] at (0,0.645\paperheight) {
-          \resizebox{1.33\paperwidth}{!}{\inserttitlegraphic}};
+          \resizebox{1.33\paperwidth}{!}{\vphantom{-}\inserttitlegraphic}};
         \fill[structure.fg!50!black,path fading=fade right img]
         (-0.66\paperwidth,0.06\paperheight)
         rectangle (0.43\paperwidth,0.53\paperheight);
@@ -272,7 +271,7 @@
       -- (\rightw,-0.53\paperheight)
       -- (\midw,-0.68\paperheight) -- cycle;
       \node[black] at (\midw,-0.65\paperheight) {
-        \resizebox{1.25\paperwidth}{!}{\inserttitlegraphic}};
+        \resizebox{1.25\paperwidth}{!}{\vphantom{-}\inserttitlegraphic}};
       \node[palette primary.bg] at (\midw,-0.2\paperheight)
         {\resizebox{!}{2.5cm}{\vphantom{-}\usebeamertemplate{logo}}};
       \node at (\midw,-0.45\paperheight) {

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/11/25 v3.0.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2023/11/25 v3.0.1 Visual Identity System library for sjtubeamer]
 \newif\ifsjtubeamer@tempif%
 \newbox\sjtubeamer@tempbox%
 \newskip\sjtubeamer@h%

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021,2022 SJTUG
+%% Copyright (C) 2021-2023 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 
-\ProvidesFile{sjtubeamer.tex}[2022/11/25 v3.0.0 User Manual for sjtubeamer (Chinese)]
+\ProvidesFile{sjtubeamer.tex}[2023/11/25 v3.0.1 User Manual for sjtubeamer (Chinese)]
 \documentclass[
     UTF8,
     heading=true,

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -264,11 +264,11 @@ bottom=0pt, fontupper=\sffamily, colupper=white}
 
 \begin{enumerate}
   \item[\faApple{} \faLinux] *nix 系统采用
-    \hologo{XeLaTeX} 编译以获得中文支持。
+        \hologo{XeLaTeX} 编译以获得中文支持。
   \item[\faWindows] Windows 系统采用
-    \hologo{pdfLaTeX} 编译以获得更快的编译速度。
+        \hologo{pdfLaTeX} 编译以获得更快的编译速度。
   \item[\faWrench] 也可以直接使用 \textsf{latexmk
-      (latexmkrc)} 编译示例的主文档。
+          (latexmkrc)} 编译示例的主文档。
 \end{enumerate}
 
 下面的代码可以用于测试 \themename{} 是否可以正常使用。
@@ -487,24 +487,24 @@ Reader}）打开演示文稿，在“视图”选单中选择“全屏模式”�
 
 \begin{enumerate}
   \item[\faChrome] Chrome 浏览器以及 *nix
-    内置的阅读器支持“演示”功能。
-    \begin{figure}[h]
-      \centering
-      \begin{tcolorbox}[enhanced,
-          title={$\vdots$}, attach boxed
-          title to top
-          right, boxed title style={
-              circular arc, top=0mm,
-              bottom=2mm,
-              left=3.25mm, right=3.25mm
-            },
-          sharp corners, tile, width=6cm]
-        演示
-      \end{tcolorbox}
-    \end{figure}
+        内置的阅读器支持“演示”功能。
+        \begin{figure}[h]
+          \centering
+          \begin{tcolorbox}[enhanced,
+              title={$\vdots$}, attach boxed
+              title to top
+              right, boxed title style={
+                  circular arc, top=0mm,
+                  bottom=2mm,
+                  left=3.25mm, right=3.25mm
+                },
+              sharp corners, tile, width=6cm]
+            演示
+          \end{tcolorbox}
+        \end{figure}
   \item[\faInternetExplorer] Edge
-    浏览器需要调整为“适应宽度”\fbox{\faArrowsAltH}，并使用
-    \fbox{\sffamily PageDown} 翻页。尽量不要使用该播放方法。
+        浏览器需要调整为“适应宽度”\fbox{\faArrowsAltH}，并使用
+        \fbox{\sffamily PageDown} 翻页。尽量不要使用该播放方法。
 \end{enumerate}
 
 \section{Pympress}

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -215,12 +215,12 @@ references.
 \themename\ has three different types of checking:
 \begin{description}
   \item[Regression test] To test the decoupling properties of the modules.
-    \texttt{l3build check}
+        \texttt{l3build check}
   \item[Unit test] To test each function separately by compiling documentation.
-    \texttt{l3build doc}
+        \texttt{l3build doc}
   \item[CI] To make an overall check by compiling a real-world presentation. It is
-    often completed in GitHub Actions when you are pulling a request. \texttt{make
-      build-dev}
+        often completed in GitHub Actions when you are pulling a request. \texttt{make
+          build-dev}
 \end{description}
 
 We use \verb"l3build" (Section \ref{sec:l3build}) mainly for coding internal

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021,2022 SJTUG
+%% Copyright (C) 2021-2023 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 
-\ProvidesFile{sjtubeamerdevguide.tex}[2022/11/25 v3.0.0 Development Guide for sjtubeamer (English)]
+\ProvidesFile{sjtubeamerdevguide.tex}[2023/11/25 v3.0.1 Development Guide for sjtubeamer (English)]
 \documentclass{ltxdoc}
 \usepackage[scheme=plain]{ctex}
 \usepackage[style=ieee]{biblatex}
@@ -1327,7 +1327,7 @@ see \texttt{build.lua}.
 \begin{quotation}
   \scriptsize
 
-  Copyright (C) 2021,2022 SJTUG
+  Copyright (C) 2021-2023 SJTUG
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not use
   this file except in compliance with the License. You may obtain a copy of the

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -1263,13 +1263,13 @@ loaded.
   \makeatother
 \end{verbatim}
 
-\begin{tabular}{c|ccccccccc}
-  \TeX\ Live & 2022    & 2021    & 2020    & 2019    & 2018    & 2017    & 2016
-             & 2015    & 2014
+\begin{tabular}{c|cccccccccc}
+  \TeX\ Live & 2023    & 2022    & 2021    & 2020    & 2019    & 2018    & 2017
+             & 2016    & 2015    & 2014
   \\
   \hline
-  Test       & $\surd$ & $\surd$ & $\surd$ & $\surd$ & $\circ$ & $\circ$ &
-  $\circ$    & $\circ$ &
+  Test       & $\surd$ & $\surd$ & $\surd$ & $\surd$ & $\surd$ & $\circ$ &
+  $\circ$    & $\circ$ & $\circ$ &
   \\
 \end{tabular}
 

--- a/src/doc/sjtubeamerquickstart.tex
+++ b/src/doc/sjtubeamerquickstart.tex
@@ -1,7 +1,7 @@
 % !TeX encoding = UTF-8
 
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021,2022 SJTUG
+%% Copyright (C) 2021-2023 SJTUG
 %% 
 %% SJTUBeamer 快速入门
 %% 
@@ -14,7 +14,7 @@
 %% -----------------------------------------------------------------------
 
 % 本行为文件元数据，可省略。
-\ProvidesFile{sjtubeamerquickstart.tex}[2022/11/25 v3.0.0 Quick Start for sjtubeamer (Chinese)]
+\ProvidesFile{sjtubeamerquickstart.tex}[2023/11/25 v3.0.1 Quick Start for sjtubeamer (Chinese)]
 
 % 加载 ctexbeamer 文档类【第一部分】
 % 如果编写英文内容，建议直接使用 beamer 文档类。

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021,2022 SJTUG
+% Copyright (C) 2021-2023 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021,2022 SJTUG
+% Copyright (C) 2021-2023 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021,2022 SJTUG
+% Copyright (C) 2021-2023 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -180,6 +180,9 @@
 %    \begin{macrocode}
 \def\inserttitlegraphic{\usebeamertemplate{titlegraphic}}
 %    \end{macrocode}
+% This redefinition makes \verb"\inserttitlegraphic" never be \verb"\@empty".
+% If we need to check if the title graphic is empty now, use
+% \verb"\ifbeamertemplateempty{titlegraphic}{}{}" instead.
 %
 % Set up titlegraphic for this cover.
 % First set to empty in case that all definitions of this template in

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021,2022 SJTUG
+% Copyright (C) 2021-2023 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021,2022 SJTUG
+% Copyright (C) 2021-2023 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2022/11/25 v3.0.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/beamerthemesjtubeamer.ins
+++ b/src/source/beamerthemesjtubeamer.ins
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021,2022 SJTUG
+%% Copyright (C) 2021-2023 SJTUG
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 \preamble
 ------------------------------------------------------------------------
-Copyright (C) 2021,2022 SJTUG
+Copyright (C) 2021-2023 SJTUG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -319,8 +319,7 @@
 % is the upper layer of this style file, the whole thing should be reimplemented here.
 %    \begin{macrocode}
   \usebeamercolor{palette primary}% 
-  \ifx\inserttitlegraphic\@empty%
-  \else
+  \ifbeamertemplateempty{titlegraphic}{}{%
     \begin{tikzpicture}[overlay, yshift=1.2em]
       \node (pic) [fg, above left, inner sep=0.32em] at (0.86\paperwidth,0)
       {\resizebox{0.3\paperwidth}{!}{\inserttitlegraphic}};
@@ -334,7 +333,7 @@
       (pic.south east) --
       (pic.south west) -- cycle;
     \end{tikzpicture}
-  \fi
+  }
   \endgroup
   \vskip0.5em
   \vfill

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -151,7 +151,7 @@
     rectangle (1*\the\paperwidth, 0.3*\the\paperheight);
     \node [palette primary.fg, inner sep=0pt]
     at (0.45\paperwidth-6pt,-0.4*\the\paperheight)
-    {\resizebox{1.3\paperwidth}{!}{\inserttitlegraphic}};
+    {\resizebox{1.3\paperwidth}{!}{\vphantom{-}\inserttitlegraphic}};
   \end{tikzpicture}
   \vfill
   \begingroup
@@ -397,7 +397,7 @@
         \clip (-0.66\paperwidth,0.06\paperheight)
         rectangle (0.43\paperwidth,0.53\paperheight);
         \node [anchor=north] at (0,0.645\paperheight) {
-          \resizebox{1.33\paperwidth}{!}{\inserttitlegraphic}};
+          \resizebox{1.33\paperwidth}{!}{\vphantom{-}\inserttitlegraphic}};
         \fill[structure.fg!50!black,path fading=fade right img]
         (-0.66\paperwidth,0.06\paperheight)
         rectangle (0.43\paperwidth,0.53\paperheight);
@@ -444,7 +444,7 @@
       -- (\rightw,-0.53\paperheight)
       -- (\midw,-0.68\paperheight) -- cycle;
       \node[black] at (\midw,-0.65\paperheight) {
-        \resizebox{1.25\paperwidth}{!}{\inserttitlegraphic}};
+        \resizebox{1.25\paperwidth}{!}{\vphantom{-}\inserttitlegraphic}};
       \node[palette primary.bg] at (\midw,-0.2\paperheight) 
         {\resizebox{!}{2.5cm}{\vphantom{-}\usebeamertemplate{logo}}};
       \node at (\midw,-0.45\paperheight) {

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -223,10 +223,6 @@
     rectangle (1*\the\paperwidth, 0.2*\the\paperheight);
   \end{tikzpicture}
 %    \end{macrocode}
-% WARNING: The pattern in the title page is now deprecated for the unstability
-% of the \verb"fadings" library in TikZ. If you want to use the pattern,
-% please uncomment the code segement manually.
-% The interface of \verb"stamparry" is functional.
 %
 % If it is in draft mode or it is not compatible, no pattern will get rendered.
 %

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2022/11/25 v3.0.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2023/11/25 v3.0.1 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -580,7 +580,7 @@
 %    \begin{macrocode}
 \def\sjtubeamer@compatible@false{false}
 %    \end{macrocode}
-% We didn't make it as an option since it will break the hierarchival structure of
+% We didn't make it as an option since it will break the hierarchical structure of
 % option definition. This is the bottom level of all style files, no advanced
 % methods are provided in this layer.
 % \end{macro}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2022/11/25 v3.0.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2023/11/25 v3.0.1 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
修复了对于头图为空的判定。加固了其他头图可能为空的情形。

Fix #155 .