### PR TITLE
fix: poster headline and footer

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -98,7 +98,7 @@ jobs:
               format(
                 env.MESSAGE,
                 steps.contrib_name.outputs.content,
-                github.event.push.commits[0].author[0],
+                github.actor,
                 join(fromJSON(steps.contrib_png.outputs.markdown_urls), '  ')
               )
             }}

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ int main(){
   * 之后通过 `latexmk -xelatex main.tex` 命令进行编译即可。
   * VSCode 用户可以使用 LaTeX Workshop 中的 “Recipe: latexmk (latexmkrc)” 进行编译。
 
-目前模版最新的稳定版是 v3.0.0。您可以在 [发布页](https://github.com/sjtug/SJTUBeamer/releases) 查看修改日志和更多资料。通常来说，SJTUBeamer 的一个稳定版本包括如下内容：
+目前模版最新的稳定版是 v3.1.0。您可以在 [发布页](https://github.com/sjtug/SJTUBeamer/releases) 查看修改日志和更多资料。通常来说，SJTUBeamer 的一个稳定版本包括如下内容：
 
 * `sjtubeamerquickstart.pdf`：SJTUBeamer 快速入门，另见对应 [源代码](https://github.com/sjtug/SJTUBeamer/blob/main/src/doc/sjtubeamerquickstart.tex)。
 * `sjtubeamer.pdf`: **强烈推荐在使用前阅读一遍 👍👍👍** SJTUBeamer 用户文档。

--- a/README_en.md
+++ b/README_en.md
@@ -142,7 +142,7 @@ Edit `main.tex` and start to use.
   * Run `latexmk -xelatex main.tex` to compile
   * VSCode LaTeX Workshop: use “Recipe: latexmk (latexmkrc)” to compile
 
-The current stable version is v3.0.0。You could visit [the release page](https://github.com/sjtug/SJTUBeamer/releases) for the changelog and more details. Generally speaking, a release of SJTUBeamer has the following content:
+The current stable version is v3.1.0。You could visit [the release page](https://github.com/sjtug/SJTUBeamer/releases) for the changelog and more details. Generally speaking, a release of SJTUBeamer has the following content:
 
 * `sjtubeamerquickstart.pdf`：SJTUBeamer Quick Start. You could also read the [source code](https://github.com/sjtug/SJTUBeamer/blob/main/src/doc/sjtubeamerquickstart.tex) of the document.
 * `sjtubeamer.pdf`: SJTUBeamer User Guide.

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamercolorthemesjtubeamer.dtx  (with options: `package')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021-2023 SJTUG
+%% Copyright (C) 2021-2024 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamerfontthemesjtubeamer.dtx  (with options: `package')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021-2023 SJTUG
+%% Copyright (C) 2021-2024 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamerinnerthemesjtubeamer.dtx  (with options: `package,maxplus,max,min,my')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021-2023 SJTUG
+%% Copyright (C) 2021-2024 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamerouterthemesjtubeamer.dtx  (with options: `package')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021-2023 SJTUG
+%% Copyright (C) 2021-2024 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -6,7 +6,7 @@
 %%
 %% beamerthemesjtubeamer.dtx  (with options: `package,maxplus,max,min,my')
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021-2023 SJTUG
+%% Copyright (C) 2021-2024 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/contrib/poster/poster.tex
+++ b/contrib/poster/poster.tex
@@ -9,7 +9,8 @@
 \addbibresource{\getcontribpath{poster}{ref.bib}}
 \usepackage{zhlipsum}
 \begin{document}
-\title{poster 子主题}
+% 当标题较长时，可以使用 \\ 换行。
+\title{poster 子主题\\使用说明}
 \author{作者}
 \logo{\zhlogo}
 \institute[Test Institute]{测试机构}

--- a/contrib/poster/sjtubeamerthemeposter.ltx
+++ b/contrib/poster/sjtubeamerthemeposter.ltx
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2022--2024 LogCreative <logcreative@outlook.com>
+%% Copyright (C) 2022-2024 LogCreative <logcreative@outlook.com>
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/contrib/poster/sjtubeamerthemeposter.ltx
+++ b/contrib/poster/sjtubeamerthemeposter.ltx
@@ -27,6 +27,19 @@
   % 修改 headline，需要在文档起始处覆盖，防止 default 的行为
   \setbeamertemplate{headline}{
     \begin{beamercolorbox}[wd=\paperwidth,sep=0.02\paperwidth]{headline}
+      \if\EqualOption{poster}{sepinst}{true}\else
+        \begin{tikzpicture}[overlay]
+          \def\stampsize{60pt}
+          \if\EqualOption{poster}{landscape}{true}
+            \def\stampheight{0.08}
+          \else
+            \def\stampheight{0.05}
+          \fi
+          \usebeamercolor{palette primary}
+          \stamparray{\stampsize}{(0.75\paperwidth,-\stampheight\paperheight)}{(\paperwidth,\stampheight\paperheight)}
+          \fill[bg, path fading=fade right] (0.74\paperwidth, -\stampheight\paperheight) rectangle (1.35\paperwidth, \stampheight\paperheight);
+        \end{tikzpicture}
+      \fi
       \begin{columns}
         \begin{column}{0.25\textwidth}
           \hspace*{0.02\paperwidth}
@@ -60,19 +73,6 @@
               \resizebox{!}{4cm}{\vphantom{-}\secondaryinstlogo[\insertshortinstitute]{\insertinstitute}{}}
             \fi
             \hspace*{0.03\paperwidth}
-          \else
-            \begin{tikzpicture}[overlay]
-              \if\EqualOption{poster}{landscape}{true}
-                \def\stampheight{0.05}
-                \def\stampsize{60pt}
-              \else
-                \def\stampheight{0.03}
-                \def\stampsize{50pt}
-              \fi
-              \usebeamercolor{palette primary}
-              \stamparray{\stampsize}{(-0.05\paperwidth,-\stampheight\paperheight)}{(\paperwidth,\stampheight\paperheight)}
-              \fill[bg, path fading=fade right] (-0.05\paperwidth, -\stampheight\paperheight) rectangle (\paperwidth, \stampheight\paperheight);
-            \end{tikzpicture}
           \fi
         \end{column}
       \end{columns}

--- a/contrib/poster/sjtubeamerthemeposter.ltx
+++ b/contrib/poster/sjtubeamerthemeposter.ltx
@@ -24,22 +24,11 @@
 % 设置 headline 颜色跟随亮色/暗色
 \setbeamercolor{headline}{parent=palette primary}
 \AtBeginDocument{
+  \newsavebox{\maintitle}  % 标题盒子变量
+  \newlength{\titlebottom} % 标题盒子的高度
   % 修改 headline，需要在文档起始处覆盖，防止 default 的行为
   \setbeamertemplate{headline}{
     \begin{beamercolorbox}[wd=\paperwidth,sep=0.02\paperwidth]{headline}
-      \if\EqualOption{poster}{sepinst}{true}\else
-        \begin{tikzpicture}[overlay]
-          \def\stampsize{60pt}
-          \if\EqualOption{poster}{landscape}{true}
-            \def\stampheight{0.08}
-          \else
-            \def\stampheight{0.05}
-          \fi
-          \usebeamercolor{palette primary}
-          \stamparray{\stampsize}{(0.75\paperwidth,-\stampheight\paperheight)}{(\paperwidth,\stampheight\paperheight)}
-          \fill[bg, path fading=fade right] (0.74\paperwidth, -\stampheight\paperheight) rectangle (1.35\paperwidth, \stampheight\paperheight);
-        \end{tikzpicture}
-      \fi
       \begin{columns}
         \begin{column}{0.25\textwidth}
           \hspace*{0.02\paperwidth}
@@ -53,6 +42,7 @@
             \fi%
           \fi%
         \end{column}
+        \savebox{\maintitle}{%
         \begin{column}{0.5\textwidth}
           \vfill
           \centering
@@ -60,10 +50,12 @@
             \color{fg}\textbf{\LARGE{\inserttitle}}\vskip2.5ex
           }
           \usebeamercolor{author in headline}{%
-            \color{fg}\large{\insertauthor}
+            \color{fg}\large{\insertauthor}%
           }
           \vfill
         \end{column}
+        }
+        \usebox{\maintitle}
         \begin{column}{0.25\textwidth}
           \if\EqualOption{poster}{sepinst}{true}
             \hfill
@@ -76,6 +68,20 @@
           \fi
         \end{column}
       \end{columns}
+      \if\EqualOption{poster}{sepinst}{true}\else
+      \begin{tikzpicture}[overlay, remember picture]
+        \def\stampsize{60pt}
+        \if\EqualOption{poster}{landscape}{true}
+          \def\stampheight{0.08}
+        \else
+          \def\stampheight{0.05}
+        \fi
+        \usebeamercolor{palette primary}
+        \setlength{\titlebottom}{\dimexpr\ht\maintitle-0.02\paperwidth\relax}
+        \stamparray{\stampsize}{(0.75\paperwidth,0.2\paperwidth)}{(\paperwidth,\titlebottom)}
+        \fill[bg, path fading=fade right] (0.75\paperwidth,0.2\paperwidth) rectangle (1.35\paperwidth, \titlebottom);
+      \end{tikzpicture}
+    \fi
     \end{beamercolorbox}
   }
 }

--- a/contrib/poster/sjtubeamerthemeposter.ltx
+++ b/contrib/poster/sjtubeamerthemeposter.ltx
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2022 LogCreative <logcreative@outlook.com>
+%% Copyright (C) 2022--2024 LogCreative <logcreative@outlook.com>
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@
           \vfill
           \centering
           \usebeamercolor{title in headline}{%
-            \color{fg}\textbf{\LARGE{\inserttitle}}\vskip2.5ex
+            \color{fg}\textbf{\LARGE{\inserttitle}}\vskip2.5ex%
           }
           \usebeamercolor{author in headline}{%
             \color{fg}\large{\insertauthor}%

--- a/contrib/poster/sjtubeamerthemeposter.ltx
+++ b/contrib/poster/sjtubeamerthemeposter.ltx
@@ -90,7 +90,12 @@
 % 底栏为空时不会出现
 \setbeamercolor{footline}{parent=palette primary}
 \setbeamertemplate{footline}{%
-  \resizebox{\paperwidth}{!}{\sjtugate[cprimary]}\vskip-6cm\par
+  \resizebox{\paperwidth}{!}{\sjtugate[cprimary]}%
+  \if\EqualOption{poster}{landscape}{true}%
+    \vskip-12cm%
+  \else%
+    \vskip-6cm%
+  \fi\par
   \posterfootlinetrue
   \ifx\posterleftfootline\relax
     \ifx\posterrightfootline\relax

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2023/11/25 v3.0.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2024/10/21 3.1.0 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2023/11/25 v3.0.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2024/10/21 3.1.0 Visual Identity System library for sjtubeamer]
 \newif\ifsjtubeamer@tempif%
 \newbox\sjtubeamer@tempbox%
 \newskip\sjtubeamer@h%

--- a/src/MANIFEST.md
+++ b/src/MANIFEST.md
@@ -33,26 +33,22 @@ These are source files for a number of purposes, including the `unpack` process 
 generates the installation files of the package. Additional files included here will also
 be installed for processing such as testing.
 
- | File                           | Flag | Description                                   |
- | ---                            | ---  | ---                                           |
- | beamerthemesjtubeamer.ins      | ‡    |                                               |
- | beamercolorthemesjtubeamer.dtx | ‡    | sjtubeamer color theme                        |
- | beamerfontthemesjtubeamer.dtx  | ‡    | sjtubeamer font theme                         |
- | beamerinnerthemesjtubeamer.dtx | ‡    | sjtubeamer inner theme                        |
- | beamerouterthemesjtubeamer.dtx | ‡    | sjtubeamer outer theme                        |
- | beamerthemesjtubeamer.dtx      | ‡    | sjtubeamer parent theme                       |
- | sjtucover.dtx                  | ‡    | cover library for sjtubeamer                  |
- | sjtuvi.dtx                     | ‡    | Visual Identity System library for sjtubeamer |
+* beamerthemesjtubeamer.ins ‡
+* beamercolorthemesjtubeamer.dtx ‡
+* beamerfontthemesjtubeamer.dtx ‡
+* beamerinnerthemesjtubeamer.dtx ‡
+* beamerouterthemesjtubeamer.dtx ‡
+* beamerthemesjtubeamer.dtx ‡
+* sjtucover.dtx ‡
+* sjtuvi.dtx ‡
 
 ### Typeset documentation source files
 
 These files are typeset using LaTeX to produce the PDF documentation for the package.
 
- | File                     | Flag | Description                                |
- | ---                      | ---  | ---                                        |
- | sjtubeamer.tex           | ‡    | User Manual for sjtubeamer (Chinese)       |
- | sjtubeamerdevguide.tex   | ‡    | Development Guide for sjtubeamer (English) |
- | sjtubeamerquickstart.tex | ‡    | Quick Start for sjtubeamer (Chinese)       |
+* sjtubeamer.tex ‡
+* sjtubeamerdevguide.tex ‡
+* sjtubeamerquickstart.tex ‡
 
 ### Derived files
 

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021-2023 SJTUG
+%% Copyright (C) 2021-2024 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 
-\ProvidesFile{sjtubeamer.tex}[2023/11/25 v3.0.1 User Manual for sjtubeamer (Chinese)]
+\ProvidesFile{sjtubeamer.tex}[2024/10/21 3.1.0 User Manual for sjtubeamer (Chinese)]
 \documentclass[
     UTF8,
     heading=true,

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021-2023 SJTUG
+%% Copyright (C) 2021-2024 SJTUG
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 
-\ProvidesFile{sjtubeamerdevguide.tex}[2023/11/25 v3.0.1 Development Guide for sjtubeamer (English)]
+\ProvidesFile{sjtubeamerdevguide.tex}[2024/10/21 3.1.0 Development Guide for sjtubeamer (English)]
 \documentclass{ltxdoc}
 \usepackage[scheme=plain]{ctex}
 \usepackage[style=ieee]{biblatex}
@@ -1327,7 +1327,7 @@ see \texttt{build.lua}.
 \begin{quotation}
   \scriptsize
 
-  Copyright (C) 2021-2023 SJTUG
+  Copyright (C) 2021-2024 SJTUG
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not use
   this file except in compliance with the License. You may obtain a copy of the

--- a/src/doc/sjtubeamerquickstart.tex
+++ b/src/doc/sjtubeamerquickstart.tex
@@ -1,7 +1,7 @@
 % !TeX encoding = UTF-8
 
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021-2023 SJTUG
+%% Copyright (C) 2021-2024 SJTUG
 %% 
 %% SJTUBeamer 快速入门
 %% 
@@ -14,7 +14,7 @@
 %% -----------------------------------------------------------------------
 
 % 本行为文件元数据，可省略。
-\ProvidesFile{sjtubeamerquickstart.tex}[2023/11/25 v3.0.1 Quick Start for sjtubeamer (Chinese)]
+\ProvidesFile{sjtubeamerquickstart.tex}[2024/10/21 3.1.0 Quick Start for sjtubeamer (Chinese)]
 
 % 加载 ctexbeamer 文档类【第一部分】
 % 如遇无法显示的数学符号，尝试对 ctexbeamer 文档类添加 no-math 选项；

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021-2023 SJTUG
+% Copyright (C) 2021-2024 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021-2023 SJTUG
+% Copyright (C) 2021-2024 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021-2023 SJTUG
+% Copyright (C) 2021-2024 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021-2023 SJTUG
+% Copyright (C) 2021-2024 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -1,5 +1,5 @@
 % \iffalse meta-comment --------------------------------------------------
-% Copyright (C) 2021-2023 SJTUG
+% Copyright (C) 2021-2024 SJTUG
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2023/11/25 v3.0.1 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/beamerthemesjtubeamer.ins
+++ b/src/source/beamerthemesjtubeamer.ins
@@ -1,5 +1,5 @@
 %% ------------------------------------------------------------------------
-%% Copyright (C) 2021-2023 SJTUG
+%% Copyright (C) 2021-2024 SJTUG
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 \preamble
 ------------------------------------------------------------------------
-Copyright (C) 2021-2023 SJTUG
+Copyright (C) 2021-2024 SJTUG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -313,6 +313,9 @@
 % The size specification should be the same as \verb"stampbox" in the inner theme.
 % Since we need a finer control on the position of the picture and the inner theme
 % is the upper layer of this style file, the whole thing should be reimplemented here.
+%
+% \changes{v3.1.0}{2024/10/21}{Fix the condition of empty titlegraphic in
+% \texttt{min} theme.}
 %    \begin{macrocode}
   \usebeamercolor{palette primary}% 
   \ifbeamertemplateempty{titlegraphic}{}{%

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2023/11/25 v3.0.1 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2024/10/21 3.1.0 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2023/11/25 v3.0.1 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2024/10/21 3.1.0 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/testfiles/color.tlg
+++ b/src/testfiles/color.tlg
@@ -1,5 +1,6 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 [1
-] [2
+]
+[2
 ]

--- a/src/testfiles/inner.tlg
+++ b/src/testfiles/inner.tlg
@@ -1,6 +1,8 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 [1
-] [2
-] [3
+]
+[2
+]
+[3
 ]


### PR DESCRIPTION
调整 poster 子主题的标题栏和底部栏的图案位置：
- 修复横向海报底部图案的间距；
- 修复海报标题为多行时右方图案不能与标题栏等高的问题；调整右方图案的横向宽度使其不遮挡海报标题
- 更新海报子标题的年份

更新版本至 3.1.0
- 更新测试样例
- 更新MANIFEST
- 更新年份
- 更新至 minted v3 支持的 CI 环境（进行中）