### PR TITLE
fix: revert \inserttitlegraphic to the original definition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - run: cat build/build-*.log
         name: display build log
         if: ${{ failure() || success() }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: |
             build/build-*.pdf
@@ -60,7 +60,7 @@ jobs:
       - run: cat build/*.log
         name: display build log
         if: ${{ failure() || success() }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: |
             build/build-*.pdf
@@ -85,7 +85,7 @@ jobs:
       - name: check if generated files are of latest version
         run: |
           git diff --exit-code
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: |
             src/build/distrib/tds/doc

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -47,7 +47,7 @@ jobs:
             sed -i "s|<policy domain=\"coder\" rights=\"none\" pattern=\"PDF\" />|<policy domain=\"coder\" rights=\"read\|write\" pattern=\"PDF\" />|g" /etc/ImageMagick-*/policy.xml
             .github/ci/build_contrib.sh -halt-on-error -time -xelatex
         name: build contrib doc with XeLaTeX
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: |
             build/contrib.*.pdf

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -35,6 +35,12 @@
 		"body": "\\bgcenterbox{$1}",
 		"description": " Define a command to make a centered\n background box easily.\n"
 	},
+	"setsjtutitlegraphic": {
+		"scope": "doctex,tex",
+		"prefix": "\\setsjtutitlegraphic",
+		"body": "\\setsjtutitlegraphic{$1}",
+		"description": " Set up titlegraphic for the native\n SJTUBeamer theme cover.\n"
+	},
 	"coverpage": {
 		"scope": "doctex,tex",
 		"prefix": "\\coverpage",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -69,10 +69,11 @@
   \setbeamertemplate{background}
     {\bgcenterbox{\sjtubg[cprimary!50,opacity=0.2]}}
 \fi
-\def\titlegraphic{\setbeamertemplate{titlegraphic}}
-\def\inserttitlegraphic{\usebeamertemplate{titlegraphic}}
-\setbeamertemplate{titlegraphic}{}
-\setbeamertemplate{titlegraphic}[\sjtubeamer@inner@cover]
+\def\setsjtutitlegraphic#1{
+  \setbeamertemplate{sjtutitlegraphic}[#1]
+  \titlegraphic{\usebeamertemplate{sjtutitlegraphic}}
+}
+\setsjtutitlegraphic{\sjtubeamer@inner@cover}
 \newdimen\beamer@sidebarwidth
 \beamer@sidebarwidth=0em
 \def\coverpage#1{

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -31,10 +31,10 @@
 \else
   \defbeamertemplate*{logo}{default}{\resizebox{!}{0.7cm}{\enlogo}}
 \fi
-\defbeamertemplate*{titlegraphic}{maxplus}{\includegraphics{vi/sjtu-vi-sjtuphoto.jpg}}
-\defbeamertemplate*{titlegraphic}{max}{\sjtubg[opacity=0.2]}
-\defbeamertemplate*{titlegraphic}{min}{\includegraphics{vi/sjtu-vi-sjtuphoto.jpg}}
-\defbeamertemplate*{titlegraphic}{my}{
+\defbeamertemplate*{sjtutitlegraphic}{maxplus}{\includegraphics{vi/sjtu-vi-sjtuphoto.jpg}}
+\defbeamertemplate*{sjtutitlegraphic}{max}{\sjtubg[opacity=0.2]}
+\defbeamertemplate*{sjtutitlegraphic}{min}{\includegraphics{vi/sjtu-vi-sjtuphoto.jpg}}
+\defbeamertemplate*{sjtutitlegraphic}{my}{
   %
   % Developer could define your title graphic here for "my"...
   %
@@ -176,7 +176,8 @@
     \usebeamerfont{date}\insertdate
   \end{beamercolorbox}
   \usebeamercolor{palette primary}%
-  \ifbeamertemplateempty{titlegraphic}{}{%
+  \ifx\inserttitlegraphic\@empty%
+  \else
     \begin{tikzpicture}[overlay, yshift=1.2em]
       \node (pic) [fg, above left, inner sep=0.32em] at (0.86\paperwidth,0)
       {\resizebox{0.3\paperwidth}{!}{\inserttitlegraphic}};
@@ -190,7 +191,7 @@
       (pic.south east) --
       (pic.south west) -- cycle;
     \end{tikzpicture}
-  }
+  \fi
   \endgroup
   \vskip0.5em
   \vfill

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2024/10/21 3.1.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2024/12/21 v3.1.1 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2024/10/21 3.1.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2024/12/21 v3.1.1 Visual Identity System library for sjtubeamer]
 \newif\ifsjtubeamer@tempif%
 \newbox\sjtubeamer@tempbox%
 \newskip\sjtubeamer@h%

--- a/src/MANIFEST.md
+++ b/src/MANIFEST.md
@@ -33,22 +33,26 @@ These are source files for a number of purposes, including the `unpack` process 
 generates the installation files of the package. Additional files included here will also
 be installed for processing such as testing.
 
-* beamerthemesjtubeamer.ins ‡
-* beamercolorthemesjtubeamer.dtx ‡
-* beamerfontthemesjtubeamer.dtx ‡
-* beamerinnerthemesjtubeamer.dtx ‡
-* beamerouterthemesjtubeamer.dtx ‡
-* beamerthemesjtubeamer.dtx ‡
-* sjtucover.dtx ‡
-* sjtuvi.dtx ‡
+ | File                           | Flag | Description                                   |
+ | ---                            | ---  | ---                                           |
+ | beamerthemesjtubeamer.ins      | ‡    |                                               |
+ | beamercolorthemesjtubeamer.dtx | ‡    | sjtubeamer color theme                        |
+ | beamerfontthemesjtubeamer.dtx  | ‡    | sjtubeamer font theme                         |
+ | beamerinnerthemesjtubeamer.dtx | ‡    | sjtubeamer inner theme                        |
+ | beamerouterthemesjtubeamer.dtx | ‡    | sjtubeamer outer theme                        |
+ | beamerthemesjtubeamer.dtx      | ‡    | sjtubeamer parent theme                       |
+ | sjtucover.dtx                  | ‡    | cover library for sjtubeamer                  |
+ | sjtuvi.dtx                     | ‡    | Visual Identity System library for sjtubeamer |
 
 ### Typeset documentation source files
 
 These files are typeset using LaTeX to produce the PDF documentation for the package.
 
-* sjtubeamer.tex ‡
-* sjtubeamerdevguide.tex ‡
-* sjtubeamerquickstart.tex ‡
+ | File                     | Flag | Description                                |
+ | ---                      | ---  | ---                                        |
+ | sjtubeamer.tex           | ‡    | User Manual for sjtubeamer (Chinese)       |
+ | sjtubeamerdevguide.tex   | ‡    | Development Guide for sjtubeamer (English) |
+ | sjtubeamerquickstart.tex | ‡    | Quick Start for sjtubeamer (Chinese)       |
 
 ### Derived files
 

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 
-\ProvidesFile{sjtubeamer.tex}[2024/10/21 3.1.0 User Manual for sjtubeamer (Chinese)]
+\ProvidesFile{sjtubeamer.tex}[2024/12/21 v3.1.1 User Manual for sjtubeamer (Chinese)]
 \documentclass[
     UTF8,
     heading=true,

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 
-\ProvidesFile{sjtubeamerdevguide.tex}[2024/10/21 3.1.0 Development Guide for sjtubeamer (English)]
+\ProvidesFile{sjtubeamerdevguide.tex}[2024/12/21 v3.1.1 Development Guide for sjtubeamer (English)]
 \documentclass{ltxdoc}
 \usepackage[scheme=plain]{ctex}
 \usepackage[style=ieee]{biblatex}

--- a/src/doc/sjtubeamerquickstart.tex
+++ b/src/doc/sjtubeamerquickstart.tex
@@ -14,7 +14,7 @@
 %% -----------------------------------------------------------------------
 
 % 本行为文件元数据，可省略。
-\ProvidesFile{sjtubeamerquickstart.tex}[2024/10/21 3.1.0 Quick Start for sjtubeamer (Chinese)]
+\ProvidesFile{sjtubeamerquickstart.tex}[2024/12/21 v3.1.1 Quick Start for sjtubeamer (Chinese)]
 
 % 加载 ctexbeamer 文档类【第一部分】
 % 如遇无法显示的数学符号，尝试对 ctexbeamer 文档类添加 no-math 选项；

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -167,29 +167,31 @@
 \fi
 %    \end{macrocode}
 %
-% Redefine the \verb"\titlegraphic" command in \verb"beamer" to implement it
-% into the beamer template management system, as is been done in \verb"\logo".
-% The original definition of \verb"\titlegraphic" is to set the command
-% \verb"\inserttitlegraphic" as its parameter directly.
+% \begin{macro}{\setsjtutitlegraphic}
+% Set up titlegraphic for the native
+% SJTUBeamer theme cover.
 %    \begin{macrocode}
-\def\titlegraphic{\setbeamertemplate{titlegraphic}}
+\def\setsjtutitlegraphic#1{
+  \setbeamertemplate{sjtutitlegraphic}[#1]
+  \titlegraphic{\usebeamertemplate{sjtutitlegraphic}}
+}
 %    \end{macrocode}
-% Redefine the \verb"\inserttitlegraphic" command to use the template
-% \verb"titlegraphic" directly, using the current color setup without
-% forming a group (not \verb"\usebeamertemplate*").
-%    \begin{macrocode}
-\def\inserttitlegraphic{\usebeamertemplate{titlegraphic}}
-%    \end{macrocode}
-% This redefinition makes \verb"\inserttitlegraphic" never be \verb"\@empty".
-% If we need to check if the title graphic is empty now, use
-% \verb"\ifbeamertemplateempty{titlegraphic}{}{}" instead.
+% From version v2.5.2 to v3.1.0, the command \verb"\inserttitlegraphic" is
+% overrided to the custom mechanism of using the beamer template
+% \verb"titlegraphic" directly (\TeX capacity exceeded), but it was soon
+% discovered that this could lead to circular references when the user tries to
+% set the titlepage to the default template where it will use the "titlegraphic"
+% template to use \verb"\inserttitlegraphic" again. This has already been solved
+% by reverting to the original definition where \verb"\titlegraphic" will set
+% the \verb"\inserttitlegraphic" directly.
+% 
+% \changes{v3.1.1}{2024/12/21}{add the command to set the native titlegraphic,
+% and remove the original way of overriding \cs{inserttitlegraphic}.}
+% \end{macro}
 %
 % Set up titlegraphic for this cover.
-% First set to empty in case that all definitions of this template in
-% \verb"sjtucover" is not extracted.
 %    \begin{macrocode}
-\setbeamertemplate{titlegraphic}{}
-\setbeamertemplate{titlegraphic}[\sjtubeamer@inner@cover]
+\setsjtutitlegraphic{\sjtubeamer@inner@cover}
 %    \end{macrocode}
 %
 % \subsubsection{Covers}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -180,10 +180,11 @@
 % overrided to the custom mechanism of using the beamer template
 % \verb"titlegraphic" directly, but it was soon discovered that this could lead
 % to circular references (\TeX{} capacity exceeded) when the user tries to set
-% the titlepage to the default template where it will use the "titlegraphic"
-% template to use \verb"\inserttitlegraphic" again. This has already been solved
-% by reverting to the original definition where \verb"\titlegraphic" will set
-% the \verb"\inserttitlegraphic" directly.
+% the title page to the default template where it will
+% \verb"\usebeamertemplate{titlegraphic}" to use \verb"\inserttitlegraphic"
+% where it will call \verb"\usebeamertemplate{titlegraphic}" again.
+% This has already been solved by reverting to the original definition where
+% \verb"\titlegraphic" will set the \verb"\inserttitlegraphic" directly.
 % 
 % \changes{v3.1.1}{2024/12/21}{add the command to set the native titlegraphic,
 % and remove the original way of overriding \cs{inserttitlegraphic}.}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -178,9 +178,9 @@
 %    \end{macrocode}
 % From version v2.5.2 to v3.1.0, the command \verb"\inserttitlegraphic" is
 % overrided to the custom mechanism of using the beamer template
-% \verb"titlegraphic" directly (\TeX capacity exceeded), but it was soon
-% discovered that this could lead to circular references when the user tries to
-% set the titlepage to the default template where it will use the "titlegraphic"
+% \verb"titlegraphic" directly, but it was soon discovered that this could lead
+% to circular references (\TeX{} capacity exceeded) when the user tries to set
+% the titlepage to the default template where it will use the "titlegraphic"
 % template to use \verb"\inserttitlegraphic" again. This has already been solved
 % by reverting to the original definition where \verb"\titlegraphic" will set
 % the \verb"\inserttitlegraphic" directly.

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2024/10/21 3.1.0 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2024/12/21 v3.1.1 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2024/10/21 3.1.0 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2024/12/21 v3.1.1 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -64,28 +64,28 @@
 % \paragraph{maxplus.}
 %    \begin{macrocode}
 %<*maxplus>
-\defbeamertemplate*{titlegraphic}{maxplus}{\includegraphics{vi/sjtu-vi-sjtuphoto.jpg}}
+\defbeamertemplate*{sjtutitlegraphic}{maxplus}{\includegraphics{vi/sjtu-vi-sjtuphoto.jpg}}
 %</maxplus>
 %    \end{macrocode}
 %
 % \paragraph{max.}
 %    \begin{macrocode}
 %<*max>
-\defbeamertemplate*{titlegraphic}{max}{\sjtubg[opacity=0.2]}
+\defbeamertemplate*{sjtutitlegraphic}{max}{\sjtubg[opacity=0.2]}
 %</max>
 %    \end{macrocode}
 %
 % \paragraph{min.}
 %    \begin{macrocode}
 %<*min>
-\defbeamertemplate*{titlegraphic}{min}{\includegraphics{vi/sjtu-vi-sjtuphoto.jpg}}
+\defbeamertemplate*{sjtutitlegraphic}{min}{\includegraphics{vi/sjtu-vi-sjtuphoto.jpg}}
 %</min>
 %    \end{macrocode}
 %
 % \paragraph{my.}
 %    \begin{macrocode}
 %<*my>
-\defbeamertemplate*{titlegraphic}{my}{
+\defbeamertemplate*{sjtutitlegraphic}{my}{
   %
   % Developer could define your title graphic here for "my"...
   %
@@ -316,9 +316,12 @@
 %
 % \changes{v3.1.0}{2024/10/21}{Fix the condition of empty titlegraphic in
 % \texttt{min} theme.}
+% \changes{v3.1.1}{2024/12/21}{Revert to the original condition of empty titlegraphic in
+% \texttt{min} theme.}
 %    \begin{macrocode}
   \usebeamercolor{palette primary}% 
-  \ifbeamertemplateempty{titlegraphic}{}{%
+  \ifx\inserttitlegraphic\@empty%
+  \else
     \begin{tikzpicture}[overlay, yshift=1.2em]
       \node (pic) [fg, above left, inner sep=0.32em] at (0.86\paperwidth,0)
       {\resizebox{0.3\paperwidth}{!}{\inserttitlegraphic}};
@@ -332,7 +335,7 @@
       (pic.south east) --
       (pic.south west) -- cycle;
     \end{tikzpicture}
-  }
+  \fi
   \endgroup
   \vskip0.5em
   \vfill

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2024/10/21 3.1.0 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2024/12/21 v3.1.1 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
撤销 #84 中对 `\inserttitlegraphic` 的重定义，如果用户需要使用 `default` 的 `title page`，会导致其在插入 `\titlepage` 时调用 `\usebeamertemplate{titlegraphic}`，而此时 `\usebeamertemplate{titlegraphic}`(default) 会调用 `\inserttitlegraphic` 然后调用 `\usebeamertemplate{titlegraphic}`，从而导致循环调用。本 PR 将使用 `sjtutitlegraphic` 的 beamer template 来管理 SJTUBeamer “原生”的头图，并添加 `\setsjtutitlegraphic` 来初始化 `\titlegraphic`。

回退 #156 关于头图为空的判定，因为现在应当使用 `\inserttitlegraphic` 是否为空来判定。