### PR TITLE
docs: fix halign space of secondinstlogo

### DIFF
--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -830,25 +830,24 @@ Reader}）打开演示文稿，在“视图”选单中选择“全屏模式”�
     raster every box/.style={
         center title,
         valign=center,
-        halign=center,
+        halign=flush center,  % center 会导致额外的单词间距
         fonttitle=\ttfamily,
         colback=white}]
 
   \tcbitem[
     title={
-        \cmd{secondaryinstlogo
-            [$\langle\textit{en}\rangle$]
-          \{$\langle\textit{zh}\rangle$\}
+        \cmd{secondaryinstlogo%
+            [$\langle\textit{en}\rangle$]%
+          \{$\langle\textit{zh}\rangle$\}%
           \{$\langle\textit{logo}\rangle$\}}}]
   \resizebox{!}{1cm}{\secondaryinstlogo
-    [School of Electronic, Information and
-      Electrical Engineering]
-    {电子信息与电气工程学院}{\zhlogo{}}}
+    [School of Mathematical Sciences]
+    {数学科学学院}{\zhlogo{}}}
 
   \tcbitem[
     title={
-        \cmd{secondaryinstlogo
-          \{$\langle\textit{en}\rangle$\}
+        \cmd{secondaryinstlogo%
+          \{$\langle\textit{en}\rangle$\}%
           \{$\langle\textit{logo}\rangle$\}}}]
   \resizebox{!}{1cm}{\secondaryinstlogo{School of
       Electronic, \\ Information and Electrical
@@ -856,9 +855,9 @@ Reader}）打开演示文稿，在“视图”选单中选择“全屏模式”�
 
   \tcbitem[
     title={
-        \cmd{secondaryinstlogo
-          \{\cmd{resizebox}\{!\}\{0.95cm\}
-          \{$\langle\textit{logo2}\rangle$\}\}
+        \cmd{secondaryinstlogo%
+          \{\cmd{resizebox}\{!\}\{0.95cm\}%
+          \{$\langle\textit{logo2}\rangle$\}\}%
           \{$\langle\textit{logo}\rangle$\}}}]
   \resizebox{!}{1cm}{\secondaryinstlogo{
       \resizebox{!}{0.95cm}

--- a/src/support/tutorial/step17+_.tex
+++ b/src/support/tutorial/step17+_.tex
@@ -3,7 +3,7 @@
 \usepackage{gbt7714}
 \begin{document}
 \begin{frame}
-  SJTUBeamer 是基于上海交通大学视觉形象系统\cite{viman}制作的 \LaTeX{} 幻灯片模板。
+  SJTUBeamer 是基于上海交通大学视觉形象系统 \cite{viman} 制作的 \LaTeX{} 幻灯片模板。
 \end{frame}
 \begin{frame}[allowframebreaks]
   \frametitle{参考文献}

--- a/src/support/tutorial/step23.tex
+++ b/src/support/tutorial/step23.tex
@@ -4,9 +4,8 @@
 \title{SJTUBeamer}
 \subtitle{使用教程}
 \author{}
-\institute[School of Electronic,
-  \\Information and Electrical Engineering]
-{电子信息与电气工程学院}
+\institute[School of Mathematical Sciences]
+{数学科学学院}
 \date{\today}
 \titlegraphic{
   \includegraphics{head.png}


### PR DESCRIPTION
修复用户文档“徽标”一节二级徽标展示中额外的横向空隙，应当使用 `flush center`（基于 LaTeX `\centering`） 而不是 `center`（基于 TeX）来设置水平居中，参见 [`pgf/TikZ` 文档](https://github.com/pgf-tikz/pgf/blob/cf50fa48461e405b95b816f3208a09daa34ca8c4/doc/generic/pgf/pgfmanual-en-tikz-shapes.tex#L1014-L1050)。

修改示例学院名。