### PR TITLE
fix: make cover frame always centered

### DIFF
--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -51,7 +51,7 @@
 		"scope": "doctex,tex",
 		"prefix": "\\definecover",
 		"body": "\\definecover{$1}",
-		"description": " Command generator for \\maketitle\n , \\makebottom and section pages.\n This command receives one parameter for\n the cover type like ``title'' or\n ``bottom''.\n"
+		"description": " Command generator for \\maketitle\n , \\makebottom, and section pages.\n This command receives one parameter for\n the cover type like ``title'' or\n ``bottom''.\n"
 	},
 	"bibliolist": {
 		"scope": "doctex,tex,latex",

--- a/.vscode/sjtubeamer.code-snippets
+++ b/.vscode/sjtubeamer.code-snippets
@@ -51,7 +51,7 @@
 		"scope": "doctex,tex",
 		"prefix": "\\definecover",
 		"body": "\\definecover{$1}",
-		"description": " Command generator for \\maketitle\n and \\makebottom.\n This command receives one parameter for\n the cover type like ``title'' or\n ``bottom''.\n"
+		"description": " Command generator for \\maketitle\n , \\makebottom and section pages.\n This command receives one parameter for\n the cover type like ``title'' or\n ``bottom''.\n"
 	},
 	"bibliolist": {
 		"scope": "doctex,tex,latex",

--- a/beamercolorthemesjtubeamer.sty
+++ b/beamercolorthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer color theme]
 \RequirePackage{sjtuvi}
 \DefineOption{color}{color}{red}
 \DefineOption{color}{color}{blue}

--- a/beamerfontthemesjtubeamer.sty
+++ b/beamerfontthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer font theme]
 \RequirePackage{silence}
 \WarningFilter{latexfont}{Font shape}
 \usefonttheme{professionalfonts}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer inner theme]
 \RequirePackage{sjtuvi}
 \RequirePackage{tcolorbox}
 \DefineOption{inner}{cover}{maxplus}

--- a/beamerinnerthemesjtubeamer.sty
+++ b/beamerinnerthemesjtubeamer.sty
@@ -97,7 +97,7 @@
     {
       \def\beamer@writeslidentry{\clearpage\beamer@notesactions}
       \ifbeamer@inframe\csname #1page\endcsname\else
-        \begin{frame}[plain]
+        \begin{frame}[c,plain]
           \csname #1page\endcsname
         \end{frame}\fi
     }

--- a/beamerouterthemesjtubeamer.sty
+++ b/beamerouterthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer outer theme]
 \RequirePackage{sjtuvi}
 \DefineOption{outer}{nav}{miniframes}
 \DefineOption{outer}{nav}{infolines}

--- a/beamerthemesjtubeamer.sty
+++ b/beamerthemesjtubeamer.sty
@@ -21,7 +21,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer parent theme]
 \DeclareOptionBeamer{maxplus}{
   \def\sjtubeamer@cover{maxplus}\def\sjtubeamer@logopos{topright}}
 \DeclareOptionBeamer{max}{

--- a/sjtucover.sty
+++ b/sjtucover.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2026/05/08 v3.1.3 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2026/05/20 v3.1.4 cover library for sjtubeamer]
 \RequirePackage{sjtuvi}
 \DefineOption{cover}{lang}{zh}
 \DefineOption{cover}{lang}{en}

--- a/sjtuvi.sty
+++ b/sjtuvi.sty
@@ -18,7 +18,7 @@
 %% see https://vi.sjtu.edu.cn/index.php/articles/bulletin/16.
 %% ------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2026/05/08 v3.1.3 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2026/05/20 v3.1.4 Visual Identity System library for sjtubeamer]
 \newif\ifsjtubeamer@tempif%
 \newbox\sjtubeamer@tempbox%
 \newskip\sjtubeamer@h%

--- a/src/doc/sjtubeamer.tex
+++ b/src/doc/sjtubeamer.tex
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 
-\ProvidesFile{sjtubeamer.tex}[2026/05/08 v3.1.3 User Manual for sjtubeamer (Chinese)]
+\ProvidesFile{sjtubeamer.tex}[2026/05/20 v3.1.4 User Manual for sjtubeamer (Chinese)]
 \documentclass[
     UTF8,
     heading=true,

--- a/src/doc/sjtubeamerdevguide.tex
+++ b/src/doc/sjtubeamerdevguide.tex
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %% ------------------------------------------------------------------------
 
-\ProvidesFile{sjtubeamerdevguide.tex}[2026/05/08 v3.1.3 Development Guide for sjtubeamer (English)]
+\ProvidesFile{sjtubeamerdevguide.tex}[2026/05/20 v3.1.4 Development Guide for sjtubeamer (English)]
 \documentclass{ltxdoc}
 \usepackage[scheme=plain]{ctex}
 \usepackage[style=ieee]{biblatex}

--- a/src/doc/sjtubeamerquickstart.tex
+++ b/src/doc/sjtubeamerquickstart.tex
@@ -14,7 +14,7 @@
 %% -----------------------------------------------------------------------
 
 % 本行为文件元数据，可省略。
-\ProvidesFile{sjtubeamerquickstart.tex}[2026/05/08 v3.1.3 Quick Start for sjtubeamer (Chinese)]
+\ProvidesFile{sjtubeamerquickstart.tex}[2026/05/20 v3.1.4 Quick Start for sjtubeamer (Chinese)]
 
 % 加载 ctexbeamer 文档类【第一部分】
 % 如遇无法显示的数学符号，尝试对 ctexbeamer 文档类添加 no-math 选项；

--- a/src/source/beamercolorthemesjtubeamer.dtx
+++ b/src/source/beamercolorthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamercolorthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer color theme]
+\ProvidesPackage{beamercolorthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer color theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerfontthemesjtubeamer.dtx
+++ b/src/source/beamerfontthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerfontthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer font theme]
+\ProvidesPackage{beamerfontthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer font theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerinnerthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer inner theme]
+\ProvidesPackage{beamerinnerthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer inner theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -238,7 +238,7 @@
 %
 % \begin{macro}{\definecover}
 % Command generator for \verb"\maketitle"
-% , \verb"\makebottom" and section pages.
+% , \verb"\makebottom", and section pages.
 % This command receives one parameter for
 % the cover type like ``title'' or
 % ``bottom''.

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -238,7 +238,7 @@
 %
 % \begin{macro}{\definecover}
 % Command generator for \verb"\maketitle"
-% and \verb"\makebottom".
+% , \verb"\makebottom" and section pages.
 % This command receives one parameter for
 % the cover type like ``title'' or
 % ``bottom''.
@@ -255,12 +255,17 @@
   \expandafter\def\csname make#1\endcsname{
     {
 %    \end{macrocode}
-% Redefinition on\verb"\beamer@writeslideentrty" locally will remove the
+% Redefinition on \verb"\beamer@writeslideentrty" locally will remove the
 % corresponding navigation dot for miniframe outer theme.
+% The frame for the covers is specified as \verb"c" to avoid the unwanted shift
+% caused by the global \verb"t" or \verb"b" option
+% (where \verb"b" may be deprecated) on \verb"beamer" class.
+% The \verb"plain" option is used to remove the header and footer 
+% for the cover page.
 %    \begin{macrocode}
       \def\beamer@writeslidentry{\clearpage\beamer@notesactions}
       \ifbeamer@inframe\csname #1page\endcsname\else
-        \begin{frame}[plain]
+        \begin{frame}[c,plain]
           \csname #1page\endcsname
         \end{frame}\fi
     }

--- a/src/source/beamerinnerthemesjtubeamer.dtx
+++ b/src/source/beamerinnerthemesjtubeamer.dtx
@@ -255,7 +255,7 @@
   \expandafter\def\csname make#1\endcsname{
     {
 %    \end{macrocode}
-% Redefinition on \verb"\beamer@writeslideentrty" locally will remove the
+% Redefinition on \verb"\beamer@writeslidentry" locally will remove the
 % corresponding navigation dot for miniframe outer theme.
 % The frame for the covers is specified as \verb"c" to avoid the unwanted shift
 % caused by the global \verb"t" or \verb"b" option

--- a/src/source/beamerouterthemesjtubeamer.dtx
+++ b/src/source/beamerouterthemesjtubeamer.dtx
@@ -16,7 +16,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerouterthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer outer theme]
+\ProvidesPackage{beamerouterthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer outer theme]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/beamerthemesjtubeamer.dtx
+++ b/src/source/beamerthemesjtubeamer.dtx
@@ -37,7 +37,7 @@
 % ------------------------------------------------------------------- \fi
 % \iffalse
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{beamerthemesjtubeamer}[2026/05/08 v3.1.3 sjtubeamer parent theme]
+\ProvidesPackage{beamerthemesjtubeamer}[2026/05/20 v3.1.4 sjtubeamer parent theme]
 % \fi
 %
 % \subsection{Parent Theme}

--- a/src/source/sjtucover.dtx
+++ b/src/source/sjtucover.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtucover}[2026/05/08 v3.1.3 cover library for sjtubeamer]
+\ProvidesPackage{sjtucover}[2026/05/20 v3.1.4 cover library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}

--- a/src/source/sjtuvi.dtx
+++ b/src/source/sjtuvi.dtx
@@ -13,7 +13,7 @@
 % \iffalse
 %<*package>
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{sjtuvi}[2026/05/08 v3.1.3 Visual Identity System library for sjtubeamer]
+\ProvidesPackage{sjtuvi}[2026/05/20 v3.1.4 Visual Identity System library for sjtubeamer]
 %</package>
 % \fi
 % \CheckSum{0}


### PR DESCRIPTION
修复在 `beamer` 或 `ctexbeamer` 文档类使用 `[t]` 选项时，封面页也会异常提升的问题。